### PR TITLE
feat: 유저의 친구 조회 API

### DIFF
--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import net.teumteum.core.context.LoginContext;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.request.UserUpdateRequest;
+import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import net.teumteum.user.service.UserService;
@@ -56,6 +57,11 @@ public class UserController {
         userService.addFriends(loginContext.getUserId(), friendId);
     }
 
+    @GetMapping("/{userId}/friends")
+    @ResponseStatus(HttpStatus.OK)
+    public FriendsResponse findFriends(@PathVariable("userId") Long userId) {
+        return userService.findFriendsByUserId(userId);
+    }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/net/teumteum/user/domain/response/FriendsResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/FriendsResponse.java
@@ -1,0 +1,54 @@
+package net.teumteum.user.domain.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import net.teumteum.user.domain.User;
+
+public record FriendsResponse(
+    List<Friend> friends
+) {
+
+    public static FriendsResponse of(List<User> users) {
+        return new FriendsResponse(
+            users.stream()
+                .map(Friend::of)
+                .toList()
+        );
+    }
+
+    public record Friend(
+        Long id,
+        Long characterId,
+        String name,
+        Job job
+    ) {
+
+        public static Friend of(User user) {
+            return new Friend(
+                user.getId(),
+                user.getCharacterId(),
+                user.getName(),
+                Job.of(user)
+            );
+        }
+
+        public record Job(
+            String name,
+            boolean certificated,
+            @JsonProperty("class")
+            String jobClass,
+            String detailClass
+        ) {
+
+            public static Job of(User user) {
+                return new Job(
+                    user.getJob().getName(),
+                    user.getJob().isCertificated(),
+                    user.getJob().getJobClass(),
+                    user.getJob().getDetailJobClass()
+                );
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserRepository;
 import net.teumteum.user.domain.request.UserUpdateRequest;
+import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import org.springframework.stereotype.Service;
@@ -50,6 +51,13 @@ public class UserService {
         var friend = getUser(friendId);
 
         me.addFriend(friend);
+    }
+
+    public FriendsResponse findFriendsByUserId(Long userId) {
+        var user = getUser(userId);
+        var friends = userRepository.findAllById(user.getFriends());
+
+        return FriendsResponse.of(friends);
     }
 
     private User getUser(Long userId) {

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -52,6 +52,13 @@ class Api {
             .exchange();
     }
 
+    ResponseSpec getFriendsByUserId(String token, Long userId) {
+        return webTestClient.get()
+            .uri("/users/" + userId + "/friends")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
+    }
+
     ResponseSpec getOpenMeetings(String token, Long cursorId, int size) {
         return webTestClient.get()
             .uri("/meetings" +

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -2,6 +2,7 @@ package net.teumteum.integration;
 
 import java.util.List;
 import net.teumteum.core.error.ErrorResponse;
+import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import org.assertj.core.api.Assertions;
@@ -142,6 +143,57 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             result.expectStatus().isOk();
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 조회 API는")
+    class Find_friends_api {
+
+        @Test
+        @DisplayName("user의 id를 입력받으면, id에 해당하는 user의 친구 목록을 반환한다.")
+        void Return_friends_when_received_user_id() {
+            // given
+            var me = repository.saveAndGetUser();
+            var friend1 = repository.saveAndGetUser();
+            var friend2 = repository.saveAndGetUser();
+
+            loginContext.setUserId(me.getId());
+            api.addFriends(VALID_TOKEN, friend1.getId());
+            api.addFriends(VALID_TOKEN, friend2.getId());
+
+            var expected = FriendsResponse.of(List.of(friend1, friend2));
+
+            // when
+            var result = api.getFriendsByUserId(VALID_TOKEN, me.getId());
+
+            // then
+            Assertions.assertThat(result.expectStatus().isOk()
+                    .expectBody(FriendsResponse.class)
+                    .returnResult()
+                    .getResponseBody())
+                .usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("user의 id를 입력받았을때, 친구가 한명도 없다면, 빈 목록을 반환한다.")
+        void Return_empty_friends_when_received_empty_friends_user_id() {
+            // given
+            var me = repository.saveAndGetUser();
+
+            loginContext.setUserId(me.getId());
+
+            var expected = FriendsResponse.of(List.of());
+
+            // when
+            var result = api.getFriendsByUserId(VALID_TOKEN, me.getId());
+
+            // then
+            Assertions.assertThat(result.expectStatus().isOk()
+                    .expectBody(FriendsResponse.class)
+                    .returnResult()
+                    .getResponseBody())
+                .usingRecursiveComparison().isEqualTo(expected);
         }
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
유저의 친구를 조회하는 API를 개발했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 친구 조회 서비스 추가
- [x] 통합테스트 구현
- [x] 응답 모델 추가
 
## 🦀 이슈 넘버
- close #26 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
