### PR TITLE
feat: 유저가 참여한 모임을 취소한다.

### DIFF
--- a/src/main/java/net/teumteum/meeting/controller/MeetingController.java
+++ b/src/main/java/net/teumteum/meeting/controller/MeetingController.java
@@ -46,6 +46,13 @@ public class MeetingController {
         return meetingService.addParticipant(meetingId, userId);
     }
 
+    @DeleteMapping("/{meetingId}/participants")
+    @ResponseStatus(HttpStatus.OK)
+public void deleteParticipant(@PathVariable("meetingId") Long meetingId) {
+        Long userId = securityService.getCurrentUserId();
+        meetingService.cancelParticipant(meetingId, userId);
+    }
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)
     public ErrorResponse handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {

--- a/src/main/java/net/teumteum/meeting/domain/Meeting.java
+++ b/src/main/java/net/teumteum/meeting/domain/Meeting.java
@@ -55,6 +55,10 @@ public class Meeting extends TimeBaseEntity {
         participantUserIds.add(userId);
     }
 
+    public void cancelParticipant(Long userId) {
+        participantUserIds.remove(userId);
+    }
+
     public boolean alreadyParticipant(Long userId) {
         return participantUserIds.contains(userId);
     }
@@ -85,5 +89,4 @@ public class Meeting extends TimeBaseEntity {
     private void assertParticipantUserIds() {
         Assert.isTrue(participantUserIds.size() + 1 <= numberOfRecruits, "최대 참여자 수에 도달한 모임에 참여할 수 없습니다." + "[최대 참여자 수] : " + numberOfRecruits + "[현재 참여자 수] : " + participantUserIds.size());
     }
-
 }

--- a/src/main/java/net/teumteum/meeting/service/MeetingService.java
+++ b/src/main/java/net/teumteum/meeting/service/MeetingService.java
@@ -74,12 +74,12 @@ public class MeetingService {
         var existMeeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException("meetingId에 해당하는 모임을 찾을 수 없습니다. \"" + meetingId + "\""));
 
-        if (!existMeeting.alreadyParticipant(userId)) {
-            throw new IllegalArgumentException("참여하지 않은 모임입니다.");
-        }
-
         if (!existMeeting.isOpen()) {
             throw new IllegalArgumentException("종료된 모임에서 참여를 취소할 수 없습니다.");
+        }
+
+        if (!existMeeting.alreadyParticipant(userId)) {
+            throw new IllegalArgumentException("참여하지 않은 모임입니다.");
         }
 
         existMeeting.cancelParticipant(userId);

--- a/src/main/java/net/teumteum/meeting/service/MeetingService.java
+++ b/src/main/java/net/teumteum/meeting/service/MeetingService.java
@@ -68,4 +68,20 @@ public class MeetingService {
         existMeeting.addParticipant(userId);
         return MeetingResponse.of(existMeeting);
     }
+
+    @Transactional
+    public void cancelParticipant(Long meetingId, Long userId) {
+        var existMeeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("meetingId에 해당하는 모임을 찾을 수 없습니다. \"" + meetingId + "\""));
+
+        if (!existMeeting.alreadyParticipant(userId)) {
+            throw new IllegalArgumentException("참여하지 않은 모임입니다.");
+        }
+
+        if (!existMeeting.isOpen()) {
+            throw new IllegalArgumentException("종료된 모임에서 참여를 취소할 수 없습니다.");
+        }
+
+        existMeeting.cancelParticipant(userId);
+    }
 }

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -102,4 +102,10 @@ class Api {
             .exchange();
     }
 
+    ResponseSpec cancelMeeting(String token, Long meetingId) {
+        return webTestClient.delete()
+            .uri("/meetings/" + meetingId + "/participants")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
+    }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
참여한 모임에 취소하는 기능 구현

## 🕶️ 어떻게 해결했나요?
- [X] 유저가 참여한 모임에 참여 취소한다.
  - [X] 유저가 참여하지 않은 모임에 대한 예외 처리
  - [X] 종료된 모임에 대한 예외 처리

## 🦀 이슈 넘버
close #33 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
