### PR TITLE
feat: 공통 관심질문 생성 기능 개발

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,17 @@
 ### PROJECT ###
 projectGroup=net.teumteum
 projectVersion=1.0
-
 ### TEST ###
 junitVersion=5.10.1
 assertJVersion=3.24.2
-
 ### LOMBOK ###
 lombokVersion=1.18.30
-
 ### SPRING ###
 springBootVersion=3.2.0
 springDependencyManagementVersion=1.1.4
-
 ### SONAR ###
 sonarVersion=4.4.1.3373
-
 ### MYSQL ###
 mysqlConnectorVersion=8.0.33
+### MOCK_WEB_SERVER ###
+mockWebServerVersion=4.12.0

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -11,5 +11,7 @@ allprojects {
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 
         testImplementation "org.assertj:assertj-core:${assertJVersion}"
+
+        testImplementation "com.squareup.okhttp3:mockwebserver:${mockWebServerVersion}"
     }
 }

--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -1,18 +1,28 @@
 package net.teumteum.user.controller;
 
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.core.security.service.SecurityService;
 import net.teumteum.user.domain.request.UserUpdateRequest;
 import net.teumteum.user.domain.response.FriendsResponse;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import net.teumteum.user.service.UserService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Arrays;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,8 +43,8 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     public UsersGetByIdResponse getUsersById(@RequestParam("id") String userIds) {
         var parsedUserIds = Arrays.stream(userIds.split(","))
-                .map(Long::valueOf)
-                .toList();
+            .map(Long::valueOf)
+            .toList();
 
         return userService.getUsersById(parsedUserIds);
     }
@@ -55,6 +65,11 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     public FriendsResponse findFriends(@PathVariable("userId") Long userId) {
         return userService.findFriendsByUserId(userId);
+    }
+
+    @GetMapping("/interests")
+    public InterestQuestionResponse getInterestQuestion(@RequestParam("user-id") List<Long> userIds) {
+        return userService.getInterestQuestionByUserIds(userIds);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/net/teumteum/user/domain/InterestQuestion.java
+++ b/src/main/java/net/teumteum/user/domain/InterestQuestion.java
@@ -1,0 +1,11 @@
+package net.teumteum.user.domain;
+
+import java.util.List;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
+
+@FunctionalInterface
+public interface InterestQuestion {
+
+    InterestQuestionResponse getQuestion(List<User> users);
+
+}

--- a/src/main/java/net/teumteum/user/domain/response/InterestQuestionResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/InterestQuestionResponse.java
@@ -1,0 +1,10 @@
+package net.teumteum.user.domain.response;
+
+import java.util.List;
+
+public record InterestQuestionResponse(
+    String topic,
+    List<String> balanceQuestion
+) {
+
+}

--- a/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
+++ b/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
@@ -1,0 +1,100 @@
+package net.teumteum.user.infra;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.teumteum.user.domain.InterestQuestion;
+import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class GptInterestQuestion implements InterestQuestion {
+
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
+
+    @Value("${gpt.token}")
+    private String gptToken;
+
+    @Override
+    public InterestQuestionResponse getQuestion(List<User> users) {
+        var interests = parseInterests(users);
+        var request = GptQuestionRequest.of(interests);
+
+        return webClient.post()
+            .bodyValue(request)
+            .header(HttpHeaders.AUTHORIZATION, gptToken)
+            .exchangeToMono(response -> {
+                if (response.statusCode().is2xxSuccessful()) {
+                    return response.bodyToMono(InterestQuestionResponse.class);
+                }
+                return response.createError();
+            })
+            .retry(5)
+            .block(Duration.ofSeconds(5));
+    }
+
+    private String parseInterests(List<User> users) {
+        var interests = new HashSet<String>();
+        for (User user : users) {
+            interests.addAll(user.getInterests().stream()
+                .toList());
+        }
+        try {
+            return objectMapper.writeValueAsString(interests);
+        } catch (JsonProcessingException jsonProcessingException) {
+            throw new IllegalStateException("관심사를 파싱하는 과정에서 에러가 발생했습니다.", jsonProcessingException);
+        }
+    }
+
+
+    private record GptQuestionRequest(
+        String model,
+        List<Message> messages
+    ) {
+
+        private static final String LANGUAGE_MODEL = "gpt-3.5-turbo-1106";
+
+
+        private static GptQuestionRequest of(String interests) {
+            return new GptQuestionRequest(
+                LANGUAGE_MODEL,
+                List.of(Message.system(), Message.user(interests))
+            );
+        }
+
+        private record Message(
+            String role,
+            String content
+        ) {
+
+            private static Message system() {
+                return new Message(
+                    "system",
+                    "You are a chatbot that receives the user's interests and creates common topics of interest"
+                        + " and balance games corresponding to the topics of interest in the form of sentences based on"
+                        + " the interests. At this time, only two choices for the balance game must be given, and the"
+                        + " choices must be separated by a comma The query results must be returned in JSON format"
+                        + " according to the form below and other The JSON value must be answered in Korean without"
+                        + " words. "
+                        + "{\\\"topic\\\": Topic of common interest, \\\"balanceQuestion\\\": [Balance game options]}"
+                );
+            }
+
+            private static Message user(String interests) {
+                return new Message(
+                    "user",
+                    interests
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
+++ b/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
@@ -21,6 +21,8 @@ import reactor.core.scheduler.Schedulers;
 @RequiredArgsConstructor
 public class GptInterestQuestion implements InterestQuestion {
 
+    private static final int MAX_RETRY_COUNT = 5;
+
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
     private final ExecutorService executorService = Executors.newCachedThreadPool();
@@ -43,7 +45,7 @@ public class GptInterestQuestion implements InterestQuestion {
                 }
                 return response.createError();
             })
-            .retry(5)
+            .retry(MAX_RETRY_COUNT)
             .subscribeOn(Schedulers.fromExecutor(executorService))
             .block(Duration.ofSeconds(5));
     }

--- a/src/main/java/net/teumteum/user/infra/WebClientConfigurer.java
+++ b/src/main/java/net/teumteum/user/infra/WebClientConfigurer.java
@@ -1,0 +1,15 @@
+package net.teumteum.user.infra;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfigurer {
+
+    @Bean
+    public WebClient gpt4WebClient() {
+        return WebClient.create("https://api.openai.com");
+    }
+
+}

--- a/src/main/java/net/teumteum/user/infra/WebClientConfigurer.java
+++ b/src/main/java/net/teumteum/user/infra/WebClientConfigurer.java
@@ -2,9 +2,11 @@ package net.teumteum.user.infra;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
+@Profile("prod")
 public class WebClientConfigurer {
 
     @Bean

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -2,10 +2,12 @@ package net.teumteum.user.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import net.teumteum.user.domain.InterestQuestion;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserRepository;
 import net.teumteum.user.domain.request.UserUpdateRequest;
 import net.teumteum.user.domain.response.FriendsResponse;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import org.springframework.util.Assert;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final InterestQuestion interestQuestion;
 
     public UserGetResponse getUserById(Long userId) {
         var existUser = getUser(userId);
@@ -63,5 +66,16 @@ public class UserService {
     private User getUser(Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("userId에 해당하는 user를 찾을 수 없습니다. \"" + userId + "\""));
+    }
+
+    public InterestQuestionResponse getInterestQuestionByUserIds(List<Long> userIds) {
+        var users = userRepository.findAllById(userIds);
+        Assert.isTrue(users.size() >= 2,
+            () -> {
+                throw new IllegalArgumentException("userIds는 2개 이상 주어져야 합니다.");
+            }
+        );
+
+        return interestQuestion.getQuestion(users);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,6 +31,10 @@ management:
       exposure:
         include: prometheus
 
+### GPT ###
+gpt:
+  token: 
+
 ## LOGGING
 logging:
   level:

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -1,5 +1,6 @@
 package net.teumteum.integration;
 
+import java.util.List;
 import net.teumteum.meeting.config.PageableHandlerMethodArgumentResolver;
 import net.teumteum.meeting.domain.Topic;
 import net.teumteum.user.domain.request.UserUpdateRequest;
@@ -22,40 +23,40 @@ class Api {
     public Api(ApplicationContext applicationContext) {
         var controllers = applicationContext.getBeansWithAnnotation(Controller.class).values();
         webTestClient = WebTestClient.bindToController(controllers.toArray())
-                .argumentResolvers(resolvers -> resolvers.addCustomResolver(new PageableHandlerMethodArgumentResolver()))
-                .build();
+            .argumentResolvers(resolvers -> resolvers.addCustomResolver(new PageableHandlerMethodArgumentResolver()))
+            .build();
     }
 
 
     ResponseSpec getUser(String token, Long userId) {
         return webTestClient
-                .get()
-                .uri("/users/" + userId)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .get()
+            .uri("/users/" + userId)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec getUsersById(String token, String userIds) {
         return webTestClient.get()
-                .uri("/users?id=" + userIds)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .uri("/users?id=" + userIds)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec updateUser(String token, UserUpdateRequest userUpdateRequest) {
         return webTestClient
-                .put()
-                .uri("/users")
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .bodyValue(userUpdateRequest)
-                .exchange();
+            .put()
+            .uri("/users")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .bodyValue(userUpdateRequest)
+            .exchange();
     }
 
     ResponseSpec addFriends(String token, Long friendId) {
         return webTestClient.post()
-                .uri("/users/" + friendId + "/friends")
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .uri("/users/" + friendId + "/friends")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec getFriendsByUserId(String token, Long userId) {
@@ -67,32 +68,32 @@ class Api {
 
     ResponseSpec getOpenMeetings(String token, Long cursorId, int size) {
         return webTestClient.get()
-                .uri("/meetings" +
-                        "?cursorId=" + cursorId +
-                        "&size=" + size)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .uri("/meetings" +
+                "?cursorId=" + cursorId +
+                "&size=" + size)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec getMeetingById(String token, Long meetingId) {
         return webTestClient.get()
-                .uri("/meetings/" + meetingId)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .uri("/meetings/" + meetingId)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec getMeetingsByTopic(String token, Pageable pageable, boolean isOpen, Topic topic) {
         String sort = pageable.getSort().toString().replace(": ", ",");
         String uri = "/meetings?sort=" + sort +
-                "&page=" + pageable.getOffset() +
-                "&size=" + pageable.getPageSize() +
-                "&isOpen=" + isOpen +
-                "&topic=" + topic;
+            "&page=" + pageable.getOffset() +
+            "&size=" + pageable.getPageSize() +
+            "&isOpen=" + isOpen +
+            "&topic=" + topic;
 
         return webTestClient.get()
-                .uri(uri)
-                .header(HttpHeaders.AUTHORIZATION, token)
-                .exchange();
+            .uri(uri)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
     }
 
     ResponseSpec joinMeeting(String token, Long meetingId) {
@@ -105,6 +106,17 @@ class Api {
     ResponseSpec cancelMeeting(String token, Long meetingId) {
         return webTestClient.delete()
             .uri("/meetings/" + meetingId + "/participants")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .exchange();
+    }
+
+    ResponseSpec getCommonInterests(String token, List<Long> userIds) {
+        var param = new StringBuilder();
+        for (Long userId : userIds) {
+            param.append(userId).append(",");
+        }
+        return webTestClient.get()
+            .uri("/users/interests?user-id=" + param.substring(0, param.length() - 1))
             .header(HttpHeaders.AUTHORIZATION, token)
             .exchange();
     }

--- a/src/test/java/net/teumteum/integration/IntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/IntegrationTest.java
@@ -1,6 +1,7 @@
 package net.teumteum.integration;
 
 import net.teumteum.Application;
+import net.teumteum.user.infra.GptTestServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +12,13 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient(timeout = "10000")
-@ContextConfiguration(classes = {Application.class, Api.class, Repository.class, SecurityContextSetting.class, TestLoginContext.class})
+@ContextConfiguration(classes = {
+    Api.class,
+    Repository.class,
+    Application.class,
+    GptTestServer.class,
+    TestLoginContext.class,
+    SecurityContextSetting.class})
 abstract public class IntegrationTest {
 
     @Autowired

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.teumteum.integration;
 
 import java.util.List;
-import java.util.stream.LongStream;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.response.FriendsResponse;
@@ -17,7 +16,6 @@ class UserIntegrationTest extends IntegrationTest {
 
     private static final String VALID_TOKEN = "VALID_TOKEN";
     private static final String INVALID_TOKEN = "IN_VALID_TOKEN";
-
 
     @Nested
     @DisplayName("유저 조회 API는")
@@ -194,26 +192,6 @@ class UserIntegrationTest extends IntegrationTest {
                     .returnResult()
                     .getResponseBody())
                 .usingRecursiveComparison().isEqualTo(expected);
-        }
-    }
-
-    @Nested
-    @DisplayName("공통 관심 질문 찾기 API는")
-    class Find_common_interests_question_api {
-
-        @Test
-        @DisplayName("유저의 id들을 입력받고, 공통 관심사 질문을 반환한다.")
-        void Return_common_interests_when_receive_user_ids() {
-            // given
-            var ids = LongStream.range(0, 4)
-                .map(value -> repository.saveAndGetUser().getId())
-                .boxed().toList();
-
-            // when
-            var result = api.getCommonInterests(VALID_TOKEN, ids);
-
-            // then
-            result.expectStatus().isOk();
         }
     }
 }

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -1,5 +1,7 @@
 package net.teumteum.integration;
 
+import java.util.List;
+import java.util.stream.LongStream;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.response.FriendsResponse;
@@ -9,8 +11,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 @DisplayName("유저 통합테스트의")
 class UserIntegrationTest extends IntegrationTest {
@@ -35,11 +35,11 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             Assertions.assertThat(
-                            result.expectStatus().isOk()
-                                    .expectBody(UserGetResponse.class)
-                                    .returnResult().getResponseBody())
-                    .usingRecursiveComparison()
-                    .isEqualTo(expected);
+                    result.expectStatus().isOk()
+                        .expectBody(UserGetResponse.class)
+                        .returnResult().getResponseBody())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
         }
 
         @Test
@@ -53,7 +53,7 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             result.expectStatus().isBadRequest()
-                    .expectBody(ErrorResponse.class);
+                .expectBody(ErrorResponse.class);
         }
     }
 
@@ -75,9 +75,9 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             Assertions.assertThat(result.expectStatus().isOk()
-                    .expectBody(UsersGetByIdResponse.class)
-                    .returnResult()
-                    .getResponseBody()
+                .expectBody(UsersGetByIdResponse.class)
+                .returnResult()
+                .getResponseBody()
             ).usingRecursiveComparison().isEqualTo(expected);
         }
 
@@ -194,6 +194,26 @@ class UserIntegrationTest extends IntegrationTest {
                     .returnResult()
                     .getResponseBody())
                 .usingRecursiveComparison().isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("공통 관심 질문 찾기 API는")
+    class Find_common_interests_question_api {
+
+        @Test
+        @DisplayName("유저의 id들을 입력받고, 공통 관심사 질문을 반환한다.")
+        void Return_common_interests_when_receive_user_ids() {
+            // given
+            var ids = LongStream.range(0, 4)
+                .map(value -> repository.saveAndGetUser().getId())
+                .boxed().toList();
+
+            // when
+            var result = api.getCommonInterests(VALID_TOKEN, ids);
+
+            // then
+            result.expectStatus().isOk();
         }
     }
 }

--- a/src/test/java/net/teumteum/user/infra/GptInterestQuestionTest.java
+++ b/src/test/java/net/teumteum/user/infra/GptInterestQuestionTest.java
@@ -1,0 +1,93 @@
+package net.teumteum.user.infra;
+
+import java.util.List;
+import net.teumteum.user.domain.InterestQuestion;
+import net.teumteum.user.domain.UserFixture;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("GptInterestQuestion 클래스의")
+@ContextConfiguration(classes = {GptInterestQuestion.class, GptTestServer.class})
+class GptInterestQuestionTest {
+
+    @Autowired
+    private GptTestServer gptTestServer;
+
+    @Autowired
+    private InterestQuestion interestQuestion;
+
+
+    @Nested
+    @DisplayName("getQuestion 메소드는")
+    class GetQuestion_method {
+
+        @Test
+        @DisplayName("user 목록을 받아서, 관심 질문을 반환한다.")
+        void Return_balance_game_when_receive_user_list() {
+            // given
+            var users = List.of(UserFixture.getDefaultUser(), UserFixture.getDefaultUser());
+            var expected = new InterestQuestionResponse(
+                "프로그래머",
+                List.of("프론트엔드", "백엔드")
+            );
+
+            gptTestServer.enqueue(expected);
+            gptTestServer.enqueue(expected);
+
+            // when
+            var result = interestQuestion.getQuestion(users);
+
+            // then
+            Assertions.assertThat(expected).isEqualTo(result);
+        }
+
+        @Test
+        @DisplayName("Gpt 서버에서 관심목록 응답을 실패해도 5번까지 retry한다.")
+        void Do_retry_when_gpt_server_cannot_receive_interests_lists() {
+            // given
+            var users = List.of(UserFixture.getDefaultUser(), UserFixture.getDefaultUser());
+            var expected = new InterestQuestionResponse(
+                "프로그래머",
+                List.of("프론트엔드", "백엔드")
+            );
+
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue(expected);
+
+            // when
+            var result = interestQuestion.getQuestion(users);
+
+            // then
+            Assertions.assertThat(expected).isEqualTo(result);
+        }
+
+        @Test
+        @DisplayName("Gpt서버에서 관심목록 조회를 5번 초과로 실패하면 IllegalStateException 을 던진다.")
+        void Throw_illegal_state_exception_exceed_5_time_to_get_common_interests() {
+            // given
+            var users = List.of(UserFixture.getDefaultUser(), UserFixture.getDefaultUser());
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+            gptTestServer.enqueue400();
+
+            // when
+            var result = Assertions.catchException(() -> interestQuestion.getQuestion(users));
+
+            // then
+            Assertions.assertThat(result.getClass()).isEqualTo(IllegalStateException.class);
+        }
+    }
+}

--- a/src/test/java/net/teumteum/user/infra/GptTestServer.java
+++ b/src/test/java/net/teumteum/user/infra/GptTestServer.java
@@ -1,0 +1,61 @@
+package net.teumteum.user.infra;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import net.teumteum.user.domain.response.InterestQuestionResponse;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public class GptTestServer {
+
+    private final MockWebServer mockWebServer = new MockWebServer();
+    private final ObjectMapper objectMapper = objectMapper();
+
+    {
+        try {
+            mockWebServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void enqueue(InterestQuestionResponse interestQuestionResponse) {
+        mockWebServer.enqueue(
+            new MockResponse().setBody(toBuffer(interestQuestionResponse))
+                .setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+        );
+    }
+
+    private Buffer toBuffer(InterestQuestionResponse interestQuestionResponse) {
+        try (var buffer = new Buffer()) {
+            return buffer.writeString(objectMapper.writeValueAsString(interestQuestionResponse),
+                Charset.defaultCharset());
+        } catch (Exception exception) {
+            throw new IllegalArgumentException(exception);
+        }
+    }
+
+    public void enqueue400() {
+        mockWebServer.enqueue(
+            new MockResponse().setResponseCode(400)
+        );
+    }
+
+    @Bean
+    private WebClient testGptWebClient(GptTestServer gptTestServer) {
+        return WebClient.create(gptTestServer.mockWebServer.url("").toString());
+    }
+
+    @Bean
+    private ObjectMapper objectMapper() {
+        var objectMapper = new ObjectMapper();
+        return objectMapper.registerModule(new ParameterNamesModule());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,6 +5,9 @@ spring.jpa.hibernated.ddl-auto=validate
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.datasource.hikari.maximum-pool-size=4
 spring.datasource.hikari.pool-name=H2_TEST_POOL
+
+gpt.token=12345678910
+
 ### FOR DEBUGGING ###
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type.descriptor.sql=trace


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
공통된 관심질문을 생성하는 기능을 개발했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 유저 id들을 입력받아서, 공통 관심질문을 생성하는 기능 개발 
		(필요한 정보가 유저 정보밖에 없고 유저 도메인에 속하는기능 같아서, URL도 `/teum-teums/interests` -> `/users/interests` 로 변경했습니다.)
- [x] GPT 연동 - (유료 결제는 아직 입니다)
- [x] GPT 테스트 격리 환경 구축및 테스트 작성

## 🦀 이슈 넘버
- close #28 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
