### PR TITLE
build: Dockerfile jdk version 21로 업그레이드

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jre-slim
+FROM openjdk:21
 
 ARG KAKAO_CLIENT_ID
 ARG KAKAO_CLIENT_SECRET


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
Dockerfile의 jdk 버전을 21로 올렸습니다.

## 🕶️ 어떻게 해결했나요?
- [x] openjdk:21 로 수정

## 🦀 이슈 넘버
- close #57 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
