### PR TITLE
fix: user 도메인 스키마가 맞지 않는 버그 수정

### DIFF
--- a/src/main/resources/db/migration/V1__create_users.sql
+++ b/src/main/resources/db/migration/V1__create_users.sql
@@ -7,7 +7,7 @@ create table if not exists users(
     birth varchar(10),
     name varchar(10),
     goal varchar(50),
-    authenticated varchar(255) not null,
+    authenticated enum ('카카오','네이버') not null,
     oauth_authenticate_info varchar(255) unique,
     city varchar(255),
     detail_job_class varchar(255),

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -9,7 +9,7 @@ create table if not exists users
     name               varchar(10),
     goal               varchar(50),
     oauth_id           varchar(255) not null unique,
-    authenticated      varchar(255) not null,
+    authenticated      enum ('카카오','네이버') not null,
     role_type          varchar(255),
     city               varchar(255),
     detail_job_class   varchar(255),


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
user 도메인의 authenticate 칼럼을 varchar(255)에서 enum으로 변경했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] authenticated varchar(255) -> enum ('카카오', '네이버)

## 🦀 이슈 넘버
- close #69 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
