### PR TITLE
fix: user domain role_type을 enum으로 변경

### DIFF
--- a/src/main/resources/db/migration/V4__update_users.sql
+++ b/src/main/resources/db/migration/V4__update_users.sql
@@ -3,4 +3,4 @@ alter table users
 alter table users
     add column oauth_id varchar(255) not null unique;
 alter table users
-    add column role_type varchar(255);
+    add column role_type enum ('ROLE_USER','ROLE_ADMIN');

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -10,7 +10,7 @@ create table if not exists users
     goal               varchar(50),
     oauth_id           varchar(255) not null unique,
     authenticated      enum ('카카오','네이버') not null,
-    role_type          varchar(255),
+    role_type          enum ('ROLE_USER','ROLE_ADMIN'),
     city               varchar(255),
     detail_job_class   varchar(255),
     job_class          varchar(255),


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
user domain ddl 의 role_type을 enum으로 변경했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] role_type varchar(255) -> role_type eunm ('ROLE_USER', 'ROLE_ADMIN')

## 🦀 이슈 넘버
- close #72 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
