### PR TITLE
feat: 회원 로그아웃을 구현한다.

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -6,6 +6,11 @@ allprojects {
     }
 
     dependencies {
+        // test container for redis
+        testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+        testImplementation "org.testcontainers:testcontainers:1.17.6"
+        testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+
         testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
         testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"

--- a/src/main/java/net/teumteum/core/security/service/SecurityService.java
+++ b/src/main/java/net/teumteum/core/security/service/SecurityService.java
@@ -12,14 +12,9 @@ public class SecurityService {
 
     private final UserConnector userConnector;
 
-    public static void clearSecurityContext() {
+    public void clearSecurityContext() {
         SecurityContextHolder.clearContext();
     }
-
-    private UserAuthentication getUserAuthentication() {
-        return (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
-    }
-
 
     public Long getCurrentUserId() {
         return getUserAuthentication() == null ? userConnector.findAllUser().get(0).getId()
@@ -35,5 +30,9 @@ public class SecurityService {
     public void setUserId(Long userId) {
         UserAuthentication userAuthentication = getUserAuthentication();
         userAuthentication.setUserId(userId);
+    }
+
+    private UserAuthentication getUserAuthentication() {
+        return (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
     }
 }

--- a/src/main/java/net/teumteum/core/security/service/SecurityService.java
+++ b/src/main/java/net/teumteum/core/security/service/SecurityService.java
@@ -12,7 +12,7 @@ public class SecurityService {
 
     private final UserConnector userConnector;
 
-    public void clearSecurityContext() {
+    public static void clearSecurityContext() {
         SecurityContextHolder.clearContext();
     }
 

--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -90,6 +90,11 @@ public class UserController {
         return userService.register(request);
     }
 
+    @PostMapping("/logouts")
+    @ResponseStatus(HttpStatus.OK)
+    public void logout() {
+        userService.logout(getCurrentUserId());
+    }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.core.security.service.RedisService;
+import net.teumteum.core.security.service.SecurityService;
 import net.teumteum.user.domain.BalanceGameType;
 import net.teumteum.user.domain.InterestQuestion;
 import net.teumteum.user.domain.User;
@@ -27,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final InterestQuestion interestQuestion;
     private final RedisService redisService;
+    private final SecurityService securityService;
 
     public UserGetResponse getUserById(Long userId) {
         var existUser = getUser(userId);
@@ -75,6 +77,13 @@ public class UserService {
         checkUserExistence(request.authenticated(), request.id());
 
         return new UserRegisterResponse(userRepository.save(request.toUser()).getId());
+    }
+
+    @Transactional
+    public void logout(Long userId) {
+        var existUser = getUser(userId);
+        redisService.deleteData(String.valueOf(existUser.getId()));
+        securityService.clearSecurityContext();
     }
 
 

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -28,7 +28,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final InterestQuestion interestQuestion;
     private final RedisService redisService;
-    private final SecurityService securityService;
 
     public UserGetResponse getUserById(Long userId) {
         var existUser = getUser(userId);
@@ -81,9 +80,9 @@ public class UserService {
 
     @Transactional
     public void logout(Long userId) {
-        var existUser = getUser(userId);
-        redisService.deleteData(String.valueOf(existUser.getId()));
-        securityService.clearSecurityContext();
+        getUser(userId);
+        redisService.deleteData(String.valueOf(userId));
+        SecurityService.clearSecurityContext();
     }
 
 

--- a/src/test/java/net/teumteum/core/config/RedisTestContainerConfig.java
+++ b/src/test/java/net/teumteum/core/config/RedisTestContainerConfig.java
@@ -1,0 +1,25 @@
+package net.teumteum.core.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class RedisTestContainerConfig implements BeforeAllCallback {
+
+    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+    private static final int REDIS_PORT = 6379;
+
+    private GenericContainer redis;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(REDIS_PORT);
+
+        redis.start();
+        System.setProperty("spring.data.redis.host", redis.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT)));
+    }
+}

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -143,4 +143,12 @@ class Api {
             .bodyValue(userRegisterRequest)
             .exchange();
     }
+
+    ResponseSpec logoutUser(String accessToken) {
+        return webTestClient
+            .post()
+            .uri("/users/logouts")
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .exchange();
+    }
 }

--- a/src/test/java/net/teumteum/integration/IntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/IntegrationTest.java
@@ -1,9 +1,11 @@
 package net.teumteum.integration;
 
 import net.teumteum.Application;
+import net.teumteum.core.config.RedisTestContainerConfig;
 import net.teumteum.user.infra.GptTestServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +14,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient(timeout = "10000")
+@ExtendWith(RedisTestContainerConfig.class)
 @ContextConfiguration(classes = {
     Api.class,
     Repository.class,

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -2,6 +2,8 @@ package net.teumteum.integration;
 
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.config.AppConfig;
 import net.teumteum.meeting.domain.Meeting;
@@ -14,16 +16,11 @@ import net.teumteum.user.domain.UserRepository;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.context.annotation.Import;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 @TestComponent
 @Import(AppConfig.class)
 @RequiredArgsConstructor
 class Repository {
+
     private final UserRepository userRepository;
 
     private final MeetingRepository meetingRepository;
@@ -36,6 +33,10 @@ class Repository {
 
     List<User> getAllUser() {
         return userRepository.findAll();
+    }
+
+    void clearUserRepository() {
+        userRepository.deleteAll();
     }
 
 
@@ -56,65 +57,65 @@ class Repository {
 
     List<Meeting> saveAndGetOpenMeetingsByTopic(int size, Topic topic) {
         var meetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithTopic(topic))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetCloseMeetingsTopic(int size, Topic topic) {
         var meetings = Stream.generate(() -> MeetingFixture.getCloseMeetingWithTopic(topic))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetOpenMeetingsByTitle(int size, String title) {
         var meetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithTitle(title))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetCloseMeetingsByTitle(int size, String title) {
         var meetings = Stream.generate(() -> MeetingFixture.getCloseMeetingWithTitle(title))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetOpenMeetingsByIntroduction(int size, String introduction) {
         var meetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithIntroduction(introduction))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetCloseMeetingsByIntroduction(int size, String introduction) {
         var meetings = Stream.generate(() -> MeetingFixture.getCloseMeetingWithIntroduction(introduction))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetOpenMeetingsByParticipantUserId(int size, Long participantUserId) {
         var meetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithParticipantUserId(participantUserId))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetCloseMeetingsByParticipantUserId(int size, Long participantUserId) {
         var meetings = Stream.generate(() -> MeetingFixture.getCloseMeetingWithParticipantUserId(participantUserId))
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
 
         return meetingRepository.saveAllAndFlush(meetings);
     }
 
     List<Meeting> saveAndGetOpenMeetings(int size) {
         var meetings = Stream.generate(MeetingFixture::getOpenMeeting)
-                .limit(size)
-                .toList();
+            .limit(size)
+            .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
 

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -1,11 +1,11 @@
 package net.teumteum.integration;
 
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.config.AppConfig;
+import net.teumteum.core.security.service.RedisService;
 import net.teumteum.meeting.domain.Meeting;
 import net.teumteum.meeting.domain.MeetingFixture;
 import net.teumteum.meeting.domain.MeetingRepository;
@@ -24,7 +24,8 @@ class Repository {
     private final UserRepository userRepository;
 
     private final MeetingRepository meetingRepository;
-    private final EntityManager entityManager;
+
+    private final RedisService redisService;
 
     User saveAndGetUser() {
         var user = UserFixture.getNullIdUser();
@@ -117,6 +118,18 @@ class Repository {
             .limit(size)
             .toList();
         return meetingRepository.saveAllAndFlush(meetings);
+    }
+
+    void saveRedisDataWithExpiration(String key, String value, Long duration) {
+        redisService.setDataWithExpiration(key, value, duration);
+    }
+
+    void deleteRedisData(String key) {
+        redisService.deleteData(key);
+    }
+
+    void getRedisData(String key) {
+        redisService.getData(key);
     }
 
     void clear() {

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -19,6 +19,7 @@ class UserIntegrationTest extends IntegrationTest {
 
     private static final String VALID_TOKEN = "VALID_TOKEN";
     private static final String INVALID_TOKEN = "IN_VALID_TOKEN";
+    private static final Long DURATION = 3600000L;
 
     @Nested
     @DisplayName("유저 조회 API는")
@@ -207,6 +208,7 @@ class UserIntegrationTest extends IntegrationTest {
         void Withdraw_user_info() {
             // given
             var me = repository.saveAndGetUser();
+            repository.saveRedisDataWithExpiration(String.valueOf(me.getId()), VALID_TOKEN, DURATION);
 
             loginContext.setUserId(me.getId());
 

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -220,8 +220,8 @@ class UserIntegrationTest extends IntegrationTest {
         }
 
         @Test
-        @DisplayName("해당 회원이 존재하지 않으면, 400 에러를 반환한다.")
-        void Return_400_error_if_user_not_exist() {
+        @DisplayName("해당 회원이 존재하지 않으면, 500 에러를 반환한다.")
+        void Return_500_error_if_user_not_exist() {
             // given
             repository.clearUserRepository();
 
@@ -229,12 +229,11 @@ class UserIntegrationTest extends IntegrationTest {
             var result = api.withdrawUser(VALID_TOKEN);
 
             // then
-            var responseBody = result.expectStatus().isBadRequest()
-                .expectBody(ErrorResponse.class)
-                .returnResult().getResponseBody();
-
-            Assertions.assertThat(responseBody)
-                .isNotNull();
+            Assertions.assertThat(result.expectStatus().is5xxServerError()
+                    .expectBody(ErrorResponse.class)
+                    .returnResult()
+                    .getResponseBody())
+                .usingRecursiveComparison().isNull();
         }
     }
 

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -1,5 +1,7 @@
 package net.teumteum.integration;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import java.util.List;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.User;
@@ -212,11 +214,13 @@ class UserIntegrationTest extends IntegrationTest {
             var result = api.withdrawUser(VALID_TOKEN);
 
             // then
-            Assertions.assertThat(result.expectStatus().isOk());
+            var responseBody = result.expectStatus().isOk();
+            assertThatCode(() -> api.withdrawUser(VALID_TOKEN))
+                .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("해당 회원이 존재하지 않으면, 500 에러를 반환한다.")
+        @DisplayName("해당 회원이 존재하지 않으면, 400 에러를 반환한다.")
         void Return_400_error_if_user_not_exist() {
             // given
             repository.clearUserRepository();
@@ -225,7 +229,12 @@ class UserIntegrationTest extends IntegrationTest {
             var result = api.withdrawUser(VALID_TOKEN);
 
             // then
-            Assertions.assertThat(result.expectStatus().is5xxServerError());
+            var responseBody = result.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult().getResponseBody();
+
+            Assertions.assertThat(responseBody)
+                .isNotNull();
         }
     }
 

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -197,6 +197,39 @@ class UserIntegrationTest extends IntegrationTest {
     }
 
     @Nested
+    @DisplayName("회원 탈퇴 API는")
+    class Withdraw_user {
+
+        @Test
+        @DisplayName("현재 로그인한 회원을 탈퇴 처리한다.")
+        void Withdraw_user_info() {
+            // given
+            var me = repository.saveAndGetUser();
+
+            loginContext.setUserId(me.getId());
+
+            // when
+            var result = api.withdrawUser(VALID_TOKEN);
+
+            // then
+            Assertions.assertThat(result.expectStatus().isOk());
+        }
+
+        @Test
+        @DisplayName("해당 회원이 존재하지 않으면, 500 에러를 반환한다.")
+        void Return_400_error_if_user_not_exist() {
+            // given
+            repository.clearUserRepository();
+
+            // when
+            var result = api.withdrawUser(VALID_TOKEN);
+
+            // then
+            Assertions.assertThat(result.expectStatus().is5xxServerError());
+        }
+    }
+
+    @Nested
     @DisplayName("회원 카드 등록 API는")
     class Register_user_card {
 

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -205,18 +205,14 @@ class UserIntegrationTest extends IntegrationTest {
 
         @Test
         @DisplayName("현재 로그인한 회원을 탈퇴 처리한다.")
-        void Withdraw_user_info() {
+        void Withdraw_user_info_api() {
             // given
             var me = repository.saveAndGetUser();
             repository.saveRedisDataWithExpiration(String.valueOf(me.getId()), VALID_TOKEN, DURATION);
 
             loginContext.setUserId(me.getId());
 
-            // when
-            var result = api.withdrawUser(VALID_TOKEN);
-
-            // then
-            var responseBody = result.expectStatus().isOk();
+            // when & then
             assertThatCode(() -> api.withdrawUser(VALID_TOKEN))
                 .doesNotThrowAnyException();
         }
@@ -241,7 +237,7 @@ class UserIntegrationTest extends IntegrationTest {
 
     @Nested
     @DisplayName("회원 카드 등록 API는")
-    class Register_user_card {
+    class Register_user_card_api {
 
         @Test
         @DisplayName("등록할 회원의 정보가 주어지면, 회원 정보를 저장한다.")
@@ -278,6 +274,23 @@ class UserIntegrationTest extends IntegrationTest {
 
             Assertions.assertThat(responseBody)
                 .isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 로그아웃 API 는")
+    class Logout_user_api {
+
+        @Test
+        @DisplayName("현재 로그인된 유저를 로그아웃 시킨다.")
+        void Logout_user() {
+            // given
+            var existUser = repository.saveAndGetUser();
+            repository.saveRedisDataWithExpiration(String.valueOf(existUser.getId()), VALID_TOKEN, DURATION);
+
+            // when & then
+            assertThatCode(() -> api.logoutUser(VALID_TOKEN))
+                .doesNotThrowAnyException();
         }
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

- 회원 로그아웃 API 을 구현한다.

## 🕶️ 어떻게 해결했나요?

- [x] 회원 로그아웃 API 구현
- [x] 통합 테스트 구현 및 테스트
## 🦀 이슈 넘버

- close #52 

## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
- https://github.com/depromeet/teum-teum-server/issues/52 브랜치는 로컬 https://github.com/depromeet/teum-teum-server/issues/73 에서 딴 브랜치라 https://github.com/depromeet/teum-teum-server/issues/73 커밋 기록이 포함되어 있습니다.
Redis 기능이 필수적인 API 라 부득이하게 https://github.com/depromeet/teum-teum-server/issues/73 에서 구현 시작했습니다.

<!--
## 참고자료
-->
