### PR TITLE
fix: GPT 토큰에 띄어쓰기가 들어가는 버그 수정

### DIFF
--- a/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
+++ b/src/main/java/net/teumteum/user/infra/GptInterestQuestion.java
@@ -40,7 +40,7 @@ public class GptInterestQuestion implements InterestQuestion {
         return webClient.post()
             .uri("/v1/chat/completions")
             .bodyValue(request)
-            .header(HttpHeaders.AUTHORIZATION, gptToken)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + gptToken)
             .exchangeToMono(response -> {
                 if (response.statusCode().is2xxSuccessful()) {
                     return response.bodyToMono(BalanceQuestionResponse.class);
@@ -60,7 +60,7 @@ public class GptInterestQuestion implements InterestQuestion {
         return webClient.post()
             .uri("/v1/chat/completions")
             .bodyValue(request)
-            .header(HttpHeaders.AUTHORIZATION, gptToken)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + gptToken)
             .exchangeToMono(response -> {
                 if (response.statusCode().is2xxSuccessful()) {
                     return response.bodyToMono(StoryQuestionResponse.class);


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
GPT 토큰이 `Bearer ...` 처럼 세팅되어있는 버그를 수정했습니다. 

## 🕶️ 어떻게 해결했나요?
- [x] 환경변수로 토큰만 받도록 하고, 토큰 type은 정적으로 바인딩 하도록 함

## 🦀 이슈 넘버
- close #95 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
