### PR TITLE
feat: 모임 삭제 기능 구현

### DIFF
--- a/src/main/java/net/teumteum/meeting/controller/MeetingController.java
+++ b/src/main/java/net/teumteum/meeting/controller/MeetingController.java
@@ -2,6 +2,7 @@ package net.teumteum.meeting.controller;
 
 import io.sentry.Sentry;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.core.security.service.SecurityService;
@@ -13,10 +14,17 @@ import net.teumteum.meeting.model.PageDto;
 import net.teumteum.meeting.service.MeetingService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,8 +38,8 @@ public class MeetingController {
     @PostMapping()
     @ResponseStatus(HttpStatus.CREATED)
     public MeetingResponse createMeeting(
-            @RequestPart @Valid CreateMeetingRequest meetingRequest,
-            @RequestPart List<MultipartFile> images) {
+        @RequestPart @Valid CreateMeetingRequest meetingRequest,
+        @RequestPart List<MultipartFile> images) {
         Long userId = securityService.getCurrentUserId();
         return meetingService.createMeeting(images, meetingRequest, userId);
     }
@@ -45,14 +53,22 @@ public class MeetingController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public PageDto<MeetingsResponse> getMeetingsOrderByDate(
-            Pageable pageable,
-            @RequestParam(value = "isOpen") boolean isOpen,
-            @RequestParam(value = "topic", required = false) Topic topic,
-            @RequestParam(value = "meetingAreaStreet", required = false) String meetingAreaStreet,
-            @RequestParam(value = "participantUserId", required = false) Long participantUserId,
-            @RequestParam(value = "searchWord", required = false) String searchWord) {
+        Pageable pageable,
+        @RequestParam(value = "isOpen") boolean isOpen,
+        @RequestParam(value = "topic", required = false) Topic topic,
+        @RequestParam(value = "meetingAreaStreet", required = false) String meetingAreaStreet,
+        @RequestParam(value = "participantUserId", required = false) Long participantUserId,
+        @RequestParam(value = "searchWord", required = false) String searchWord) {
 
-        return meetingService.getMeetingsBySpecification(pageable, topic, meetingAreaStreet, participantUserId, searchWord, isOpen);
+        return meetingService.getMeetingsBySpecification(pageable, topic, meetingAreaStreet, participantUserId,
+            searchWord, isOpen);
+    }
+
+    @DeleteMapping("/{meetingId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteMeeting(@PathVariable("meetingId") Long meetingId) {
+        Long userId = securityService.getCurrentUserId();
+        meetingService.deleteMeeting(meetingId, userId);
     }
 
     @PostMapping("/{meetingId}/participants")

--- a/src/main/java/net/teumteum/meeting/domain/Meeting.java
+++ b/src/main/java/net/teumteum/meeting/domain/Meeting.java
@@ -72,6 +72,10 @@ public class Meeting extends TimeBaseEntity {
         return promiseDateTime.isAfter(LocalDateTime.now());
     }
 
+    public boolean isHost(Long userId) {
+        return hostUserId.equals(userId);
+    }
+
     @PrePersist
     private void assertField() {
         assertTitle();
@@ -81,21 +85,22 @@ public class Meeting extends TimeBaseEntity {
 
     private void assertIntroduction() {
         Assert.isTrue(introduction.length() >= 10 && introduction.length() <= 200,
-                "모임 소개는 10자 ~ 200자 사이가 되어야 합니다. [현재 입력된 모임 소개] : " + introduction);
+            "모임 소개는 10자 ~ 200자 사이가 되어야 합니다. [현재 입력된 모임 소개] : " + introduction);
     }
 
     private void assertNumberOfRecruits() {
-        Assert.isTrue(numberOfRecruits >= 3 && numberOfRecruits <= 6, "참여자 수는 3명 ~ 6명 사이가 되어야 합니다. [현재 입력된 참여자 수] : " + numberOfRecruits);
+        Assert.isTrue(numberOfRecruits >= 3 && numberOfRecruits <= 6,
+            "참여자 수는 3명 ~ 6명 사이가 되어야 합니다. [현재 입력된 참여자 수] : " + numberOfRecruits);
     }
 
     private void assertTitle() {
         Assert.isTrue(title.length() >= 2 && title.length() <= 32,
-                "모임 제목은 2자 ~ 32자 사이가 되어야 합니다. [현재 입력된 모임 제목] : " + title);
+            "모임 제목은 2자 ~ 32자 사이가 되어야 합니다. [현재 입력된 모임 제목] : " + title);
     }
 
     private void assertParticipantUserIds() {
         Assert.isTrue(participantUserIds.size() + 1 <= numberOfRecruits,
-                "최대 참여자 수에 도달한 모임에 참여할 수 없습니다." + "[최대 참여자 수] : " + numberOfRecruits + "[현재 참여자 수] : "
-                        + participantUserIds.size());
+            "최대 참여자 수에 도달한 모임에 참여할 수 없습니다." + "[최대 참여자 수] : " + numberOfRecruits + "[현재 참여자 수] : "
+                + participantUserIds.size());
     }
 }

--- a/src/main/java/net/teumteum/meeting/service/MeetingService.java
+++ b/src/main/java/net/teumteum/meeting/service/MeetingService.java
@@ -66,6 +66,9 @@ public class MeetingService {
         if (!existMeeting.isHost(userId)) {
             throw new IllegalArgumentException("모임을 삭제할 권한이 없습니다.");
         }
+        if (!existMeeting.isOpen()) {
+            throw new IllegalArgumentException("종료된 모임은 삭제할 수 없습니다.");
+        }
 
         meetingRepository.delete(existMeeting);
     }

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -151,4 +151,12 @@ class Api {
             .header(HttpHeaders.AUTHORIZATION, accessToken)
             .exchange();
     }
+
+    ResponseSpec deleteMeeting(String accessToken, Long meetingId) {
+        return webTestClient
+            .delete()
+            .uri("/meetings/" + meetingId)
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .exchange();
+    }
 }

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -1,7 +1,6 @@
 package net.teumteum.integration;
 
 
-import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +49,16 @@ public class Repository {
 
     Meeting saveAndGetCloseMeeting() {
         var meeting = MeetingFixture.getCloseMeeting();
+        return meetingRepository.saveAndFlush(meeting);
+    }
+
+    Meeting saveAndGetOpenMeetingWithHostId(Long hostId) {
+        var meeting = MeetingFixture.getOpenMeetingWithHostId(hostId);
+        return meetingRepository.saveAndFlush(meeting);
+    }
+
+    Meeting saveAndGetCloseMeetingWithHostId(Long hostId) {
+        var meeting = MeetingFixture.getCloseMeetingWithHostId(hostId);
         return meetingRepository.saveAndFlush(meeting);
     }
 

--- a/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
@@ -110,7 +110,7 @@ public class MeetingFixture {
 
     public static Meeting getOpenMeetingWithHostId(Long hostId) {
         return newMeetingByBuilder(MeetingBuilder.builder()
-            .promiseDateTime(LocalDateTime.of(2000, 1, 1, 0, 0))
+            .promiseDateTime(LocalDateTime.of(4000, 1, 1, 0, 0))
             .hostUserId(hostId)
             .build()
         );

--- a/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
@@ -108,6 +108,22 @@ public class MeetingFixture {
         );
     }
 
+    public static Meeting getOpenMeetingWithHostId(Long hostId) {
+        return newMeetingByBuilder(MeetingBuilder.builder()
+            .promiseDateTime(LocalDateTime.of(2000, 1, 1, 0, 0))
+            .hostUserId(hostId)
+            .build()
+        );
+    }
+
+    public static Meeting getCloseMeetingWithHostId(Long hostId) {
+        return newMeetingByBuilder(MeetingBuilder.builder()
+            .promiseDateTime(LocalDateTime.of(2000, 1, 1, 0, 0))
+            .hostUserId(hostId)
+            .build()
+        );
+    }
+
     public static Meeting newMeetingByBuilder(MeetingBuilder meetingBuilder) {
         return new Meeting(
                 meetingBuilder.id,

--- a/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
@@ -64,24 +64,49 @@ class MeetingRepositoryTest {
 
             // then
             Assertions.assertThat(result)
-                    .isPresent()
-                    .usingRecursiveComparison()
-                    .ignoringFields("value.createdAt", "value.updatedAt")
-                    .isEqualTo(Optional.of(existsMeeting));
+                .isPresent()
+                .usingRecursiveComparison()
+                .ignoringFields("value.createdAt", "value.updatedAt")
+                .isEqualTo(Optional.of(existsMeeting));
+        }
+    }
+
+    @Nested
+    @DisplayName("delete 메소드는")
+    class Delete_method {
+
+        @Test
+        @DisplayName("모임을 삭제한 유저가 모임의 주최자이면 (hostId = userId), 모임 삭제에 성공한다.")
+        void Delete_success_if_exists_meeting_input() {
+            // given
+            var existsMeeting = MeetingFixture.getDefaultMeeting();
+
+            meetingRepository.saveAndFlush(existsMeeting);
+            entityManager.clear();
+
+            // when
+            meetingRepository.delete(existsMeeting);
+            entityManager.flush();
+            entityManager.clear();
+
+            // then
+            var result = meetingRepository.findById(existsMeeting.getId());
+            Assertions.assertThat(result).isEmpty();
         }
     }
 
     @Nested
     @DisplayName("JPA Specification을 이용한 findAll 메소드 중")
     class FindAllWithSpecificationAndPageNation_method {
+
         @Test
         @DisplayName("저장된 모임들을 주어진 topic을 가진 모임을 페이지 네이션을 적용해 최신순으로 조회하면, 모임들을 반환한다.")
         void Find_success_if_exists_meetings_topic_and_page_nation_input() {
             // given
             var createSize = 3;
             var expectedMeetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithTopic(Topic.스터디))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
             meetingRepository.saveAllAndFlush(expectedMeetings);
             entityManager.clear();
@@ -95,13 +120,13 @@ class MeetingRepositoryTest {
 
             // then
             Assertions.assertThat(result.getContent())
-                    .usingRecursiveComparison()
-                    .ignoringFields("createdAt", "updatedAt")
-                    .isEqualTo(
-                            expectedMeetings.stream()
-                                    .sorted(Comparator.comparing(Meeting::getId).reversed())
-                                    .toList()
-                    );
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(
+                    expectedMeetings.stream()
+                        .sorted(Comparator.comparing(Meeting::getId).reversed())
+                        .toList()
+                );
         }
 
         @Test
@@ -110,8 +135,8 @@ class MeetingRepositoryTest {
             // given
             var createSize = 3;
             var expectedMeetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithParticipantUserId(2L))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
             meetingRepository.saveAllAndFlush(expectedMeetings);
             entityManager.clear();
@@ -120,18 +145,19 @@ class MeetingRepositoryTest {
             var requestParticipantUserId = 2L;
 
             // when
-            var spec = MeetingSpecification.withIsOpen(true).and(MeetingSpecification.withParticipantUserId(requestParticipantUserId));
+            var spec = MeetingSpecification.withIsOpen(true)
+                .and(MeetingSpecification.withParticipantUserId(requestParticipantUserId));
             var result = meetingRepository.findAll(spec, requestPageable);
 
             // then
             Assertions.assertThat(result.getContent())
-                    .usingRecursiveComparison()
-                    .ignoringFields("createdAt", "updatedAt")
-                    .isEqualTo(
-                            expectedMeetings.stream()
-                                    .sorted(Comparator.comparing(Meeting::getId).reversed())
-                                    .toList()
-                    );
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(
+                    expectedMeetings.stream()
+                        .sorted(Comparator.comparing(Meeting::getId).reversed())
+                        .toList()
+                );
         }
 
         @Test
@@ -141,12 +167,12 @@ class MeetingRepositoryTest {
             var createSize = 3;
 
             var expectedMeetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithMainStreet("강남"))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
             var existsWrongMeetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithMainStreet("판교"))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
             meetingRepository.saveAll(expectedMeetings);
             meetingRepository.saveAllAndFlush(existsWrongMeetings);
@@ -161,13 +187,13 @@ class MeetingRepositoryTest {
 
             // then
             Assertions.assertThat(result.getContent())
-                    .usingRecursiveComparison()
-                    .ignoringFields("createdAt", "updatedAt")
-                    .isEqualTo(
-                            expectedMeetings.stream()
-                                    .sorted(Comparator.comparing(Meeting::getId).reversed())
-                                    .toList()
-                    );
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(
+                    expectedMeetings.stream()
+                        .sorted(Comparator.comparing(Meeting::getId).reversed())
+                        .toList()
+                );
         }
 
         @Test
@@ -176,18 +202,18 @@ class MeetingRepositoryTest {
             // given
             var createSize = 3;
 
-
             var existsCloseMeetings = Stream.generate(() -> MeetingFixture.getCloseMeetingWithTitle("공부팟 모집"))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
             var existsMeetingsWithTitle = Stream.generate(() -> MeetingFixture.getOpenMeetingWithTitle("공부팟 모집"))
-                    .limit(createSize)
-                    .toList();
+                .limit(createSize)
+                .toList();
 
-            var existsMeetingsWithIntroduction = Stream.generate(() -> MeetingFixture.getOpenMeetingWithIntroduction("공부하는 모임입니다."))
-                    .limit(createSize)
-                    .toList();
+            var existsMeetingsWithIntroduction = Stream.generate(
+                    () -> MeetingFixture.getOpenMeetingWithIntroduction("공부하는 모임입니다."))
+                .limit(createSize)
+                .toList();
 
             meetingRepository.saveAll(existsCloseMeetings);
             meetingRepository.saveAll(existsMeetingsWithTitle);
@@ -199,21 +225,21 @@ class MeetingRepositoryTest {
 
             // when
             var spec = MeetingSpecification.withSearchWordInTitle(requestSearchWord)
-                    .or(MeetingSpecification.withSearchWordInIntroduction(requestSearchWord))
-                    .and(MeetingSpecification.withIsOpen(true));
+                .or(MeetingSpecification.withSearchWordInIntroduction(requestSearchWord))
+                .and(MeetingSpecification.withIsOpen(true));
 
             var result = meetingRepository.findAll(spec, requestPageable);
 
             // then
             Assertions.assertThat(result.getContent())
-                    .usingRecursiveComparison()
-                    .ignoringFields("createdAt", "updatedAt")
-                    .isEqualTo(
-                            Stream.of(existsMeetingsWithTitle, existsMeetingsWithIntroduction)
-                                    .flatMap(Collection::stream)
-                                    .sorted(Comparator.comparing(Meeting::getId).reversed())
-                                    .toList()
-                    );
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(
+                    Stream.of(existsMeetingsWithTitle, existsMeetingsWithIntroduction)
+                        .flatMap(Collection::stream)
+                        .sorted(Comparator.comparing(Meeting::getId).reversed())
+                        .toList()
+                );
         }
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
모임 삭제 기능 구현

## 🕶️ 어떻게 해결했나요?
- [X] 모임 삭제 기능 구현
- [X] 종료된 모임에 대한 예외 처리 (종료된 모임은 삭제할 수 없습니다.)

## 🦀 이슈 넘버
Close #76 

## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
- 인텔리제이 포매터 고쳐서 수정 사항이 많아보이지만 별로 없습니다..
- 삭제 관련된 부분만 집중해서 봐주세오.. 🙏

<!--
## 참고자료
-->
