### PR TITLE
refactor: JWT 에러 응답 리팩토링 및 인가 인증 예최 처리 코드 수정

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,4 @@ sentryVersion=4.1.1
 ### AWS-CLOUD ###
 springCloudAwsVersion=3.1.0
 ### JWT ###
-jwtVersion=0.9.1
-jwtBindingVersion=4.0.1
-jwtJaxbApiVersion=2.3.1
+jwtVersion=0.11.5

--- a/gradle/devtool.gradle
+++ b/gradle/devtool.gradle
@@ -3,13 +3,9 @@ allprojects {
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor "org.projectlombok:lombok"
 
-        implementation "io.jsonwebtoken:jjwt:${jwtVersion}"
-
-        // com.sun.xml.bind
-        implementation "com.sun.xml.bind:jaxb-impl:${jwtBindingVersion}"
-        implementation "com.sun.xml.bind:jaxb-core:${jwtBindingVersion}"
-        // javax.xml.bind
-        implementation "javax.xml.bind:jaxb-api:${jwtJaxbApiVersion}"
+        implementation "io.jsonwebtoken:jjwt-api:${jwtVersion}"
+        runtimeOnly "io.jsonwebtoken:jjwt-impl:${jwtVersion}"
+        runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jwtVersion}"
 
         testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
         testAnnotationProcessor "org.projectlombok:lombok"

--- a/src/main/java/net/teumteum/auth/service/AuthService.java
+++ b/src/main/java/net/teumteum/auth/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
     }
 
     public Optional<User> findUserByAccessToken(String accessToken) {
-        return userConnector.findUserById(Long.parseLong(jwtService.getUserIdFromToken(accessToken)));
+        return userConnector.findUserById(jwtService.getUserIdFromToken(accessToken));
     }
 
     private void checkRefreshTokenValidation(String refreshToken) {

--- a/src/main/java/net/teumteum/auth/service/AuthService.java
+++ b/src/main/java/net/teumteum/auth/service/AuthService.java
@@ -1,7 +1,6 @@
 package net.teumteum.auth.service;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.teumteum.auth.domain.response.TokenResponse;
@@ -25,16 +24,15 @@ public class AuthService {
         String accessToken = jwtService.extractAccessToken(request);
 
         checkRefreshTokenValidation(refreshToken);
-
-        User user = findUserByAccessToken(accessToken).orElseThrow(
-            () -> new IllegalArgumentException("access token 에 해당하는 user를 찾을 수 없습니다."));
+        User user = findUserByAccessToken(accessToken);
 
         checkRefreshTokenMatch(user, refreshToken);
         return issueNewToken(user);
     }
 
-    public Optional<User> findUserByAccessToken(String accessToken) {
-        return userConnector.findUserById(jwtService.getUserIdFromToken(accessToken));
+    public User findUserByAccessToken(String accessToken) {
+        return userConnector.findUserById(jwtService.getUserIdFromToken(accessToken))
+            .orElseThrow(() -> new IllegalArgumentException("access token 에 해당하는 user를 찾을 수 없습니다."));
     }
 
     private void checkRefreshTokenValidation(String refreshToken) {

--- a/src/main/java/net/teumteum/auth/service/OAuthService.java
+++ b/src/main/java/net/teumteum/auth/service/OAuthService.java
@@ -46,7 +46,7 @@ public class OAuthService {
             registrationId);
         Authenticated authenticated = getAuthenticated(clientRegistration.getRegistrationId());
         OAuthUserInfo oAuthUserInfo = getOAuthUserInfo(clientRegistration, authenticated, code);
-        return checkUserAndMakeResponse(oAuthUserInfo, authenticated);
+        return makeResponse(oAuthUserInfo, authenticated);
     }
 
     private Authenticated getAuthenticated(String registrationId) {
@@ -65,7 +65,7 @@ public class OAuthService {
         return new KakaoOAuthUserInfo(oAuthAttribute);
     }
 
-    private TokenResponse checkUserAndMakeResponse(OAuthUserInfo oAuthUserInfo, Authenticated authenticated) {
+    private TokenResponse makeResponse(OAuthUserInfo oAuthUserInfo, Authenticated authenticated) {
         String oauthId = oAuthUserInfo.getOAuthId();
 
         return getUser(oauthId, authenticated)

--- a/src/main/java/net/teumteum/core/security/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAccessDeniedHandler.java
@@ -1,31 +1,37 @@
 package net.teumteum.core.security.filter;
 
-import jakarta.servlet.ServletException;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
 import lombok.extern.slf4j.Slf4j;
+import net.teumteum.core.error.ErrorResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
-import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-
 @Slf4j
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
     @Override
     public void handle(HttpServletRequest request,
-                       HttpServletResponse response,
-                       AccessDeniedException accessDeniedException
-    ) throws IOException, ServletException {
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
         this.sendUnAuthorizedError(response, accessDeniedException);
     }
 
     private void sendUnAuthorizedError(HttpServletResponse response,
-                                       Exception exception) throws IOException {
+        Exception exception) throws IOException {
+        response.setStatus(SC_FORBIDDEN);
+        OutputStream os = response.getOutputStream();
+        ObjectMapper objectMapper = new ObjectMapper();
         log.error("Responding with unauthorized error. Message - {}", exception.getMessage());
-        response.sendError(SC_FORBIDDEN, exception.getMessage());
+        objectMapper.writeValue(os, ErrorResponse.of("인가 과정에서 오류가 발생했습니다."));
+        os.flush();
     }
 }

--- a/src/main/java/net/teumteum/core/security/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAccessDeniedHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.teumteum.core.error.ErrorResponse;
 import org.springframework.security.access.AccessDeniedException;
@@ -15,7 +16,10 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request,
@@ -29,7 +33,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         Exception exception) throws IOException {
         response.setStatus(SC_FORBIDDEN);
         OutputStream os = response.getOutputStream();
-        ObjectMapper objectMapper = new ObjectMapper();
         log.error("Responding with unauthorized error. Message - {}", exception.getMessage());
         objectMapper.writeValue(os, ErrorResponse.of("인가 과정에서 오류가 발생했습니다."));
         os.flush();

--- a/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationEntryPoint.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.teumteum.core.error.ErrorResponse;
 import org.springframework.security.core.AuthenticationException;
@@ -15,9 +16,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private static final String ATTRIBUTE_NAME = "exception";
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -29,7 +33,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         throws IOException {
         response.setStatus(SC_UNAUTHORIZED);
         OutputStream os = response.getOutputStream();
-        ObjectMapper objectMapper = new ObjectMapper();
         log.error("Responding with unauthenticated error. Message - {}", exception.getMessage());
         objectMapper.writeValue(os, ErrorResponse.of((String) request.getAttribute(ATTRIBUTE_NAME)));
         os.flush();

--- a/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package net.teumteum.core.security.filter;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,20 +17,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private static final String ATTRIBUTE_NAME = "exception";
+
     @Override
-    public void commence(HttpServletRequest request,
-        HttpServletResponse response,
-        AuthenticationException authenticationException
-    ) throws IOException {
-        this.sendUnAuthenticatedError(response, authenticationException);
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authenticationException) throws IOException {
+        this.sendUnAuthenticatedError(request, response, authenticationException);
     }
 
-    private void sendUnAuthenticatedError(HttpServletResponse response,
-        Exception exception) throws IOException {
+    private void sendUnAuthenticatedError(HttpServletRequest request, HttpServletResponse response, Exception exception)
+        throws IOException {
+        response.setStatus(SC_UNAUTHORIZED);
         OutputStream os = response.getOutputStream();
         ObjectMapper objectMapper = new ObjectMapper();
         log.error("Responding with unauthenticated error. Message - {}", exception.getMessage());
-        objectMapper.writeValue(os, ErrorResponse.of("인증 과정에서 오류가 발생했습니다."));
+        objectMapper.writeValue(os, ErrorResponse.of((String) request.getAttribute(ATTRIBUTE_NAME)));
         os.flush();
     }
 }

--- a/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
@@ -14,7 +14,6 @@ import net.teumteum.core.security.service.JwtService;
 import net.teumteum.user.domain.User;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -52,8 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private User getUser(String token) {
-        return this.authService.findUserByAccessToken(token)
-            .orElseThrow(() -> new UsernameNotFoundException("일치하는 회원 정보가 존재하지 않습니다."));
+        return this.authService.findUserByAccessToken(token);
     }
 
     private boolean checkTokenExistenceAndValidation(HttpServletRequest request, String token) {

--- a/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
@@ -25,6 +25,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String ATTRIBUTE_NAME = "exception";
+
     private final JwtService jwtService;
     private final AuthService authService;
     private final JwtProperty jwtProperty;
@@ -39,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             String token = this.resolveTokenFromRequest(request);
-            if (checkTokenExistenceAndValidation(token)) {
+            if (checkTokenExistenceAndValidation(request, token)) {
                 User user = getUser(token);
                 saveUserAuthentication(user);
             }
@@ -54,8 +56,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             .orElseThrow(() -> new UsernameNotFoundException("일치하는 회원 정보가 존재하지 않습니다."));
     }
 
-    private boolean checkTokenExistenceAndValidation(String token) {
-        return StringUtils.hasText(token) && this.jwtService.validateToken(token);
+    private boolean checkTokenExistenceAndValidation(HttpServletRequest request, String token) {
+        if (!StringUtils.hasText(token)) {
+            setRequestAttribute(request, "요청에 대한 JWT 정보가 존재하지 않습니다.");
+            return false;
+        }
+        if (!jwtService.validateToken(token)) {
+            setRequestAttribute(request, "요청에 대한 JWT 가 유효하지 않습니다.");
+            return false;
+        }
+        return true;
     }
 
     private void saveUserAuthentication(User user) {
@@ -66,8 +76,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveTokenFromRequest(HttpServletRequest request) {
         String token = request.getHeader(jwtProperty.getAccess().getHeader());
         if (!ObjectUtils.isEmpty(token) && token.toLowerCase().startsWith(jwtProperty.getBearer().toLowerCase())) {
-            return token.substring(jwtProperty.getBearer().length()).trim();
+            return token.substring(7);
         }
+        setRequestAttribute(request, "요청에 대한 JWT 파싱 과정에서 문제가 발생했습니다.");
         return null;
+    }
+
+    private void setRequestAttribute(HttpServletRequest request, String name) {
+        request.setAttribute(ATTRIBUTE_NAME, name);
     }
 }

--- a/src/test/java/net/teumteum/core/property/PropertyTest.java
+++ b/src/test/java/net/teumteum/core/property/PropertyTest.java
@@ -55,11 +55,10 @@ class PropertyTest {
         void Make_jwt_property_from_application_yml() {
             // given
             String expectedBearer = "Bearer";
-            String expectedSecret = "secret";
 
             // when & then
             Assertions.assertEquals(expectedBearer, jwtProperty.getBearer());
-            Assertions.assertEquals(expectedSecret, jwtProperty.getSecret());
+            Assertions.assertNotNull(jwtProperty.getSecret());
         }
     }
 }

--- a/src/test/java/net/teumteum/unit/auth/service/AuthServiceTest.java
+++ b/src/test/java/net/teumteum/unit/auth/service/AuthServiceTest.java
@@ -59,7 +59,7 @@ public class AuthServiceTest {
 
             given(jwtService.extractRefreshToken(any(HttpServletRequest.class))).willReturn("refresh token");
 
-            given(jwtService.getUserIdFromToken(anyString())).willReturn("1");
+            given(jwtService.getUserIdFromToken(anyString())).willReturn(1L);
 
             given(jwtService.createAccessToken(anyString())).willReturn("new access token");
 
@@ -85,6 +85,7 @@ public class AuthServiceTest {
         @Test
         @DisplayName("유효하지 않은 access token 과 유효하지 않은 refresh token 이 주어지면, 500 server 에러로 응답한다. ")
         void Return_500_bad_request_if_refresh_token_is_not_valid() {
+            // given
             Optional<User> user = Optional.of(new User(1L, "oauthId", 네이버));
 
             HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
@@ -95,14 +96,14 @@ public class AuthServiceTest {
 
             given(jwtService.validateToken(anyString())).willReturn(true);
 
-            given(jwtService.getUserIdFromToken(anyString())).willReturn("1");
+            given(jwtService.getUserIdFromToken(anyString())).willReturn(1L);
 
             given(userConnector.findUserById(anyLong())).willReturn(user);
 
             given(redisService.getData(anyString())).willThrow(
                 new IllegalArgumentException("refresh token 이 일치하지 않습니다."));
 
-            // when
+            // when & then
             assertThatThrownBy(() -> authService.reissue(httpServletRequest)).isInstanceOf(
                 IllegalArgumentException.class).hasMessage("refresh token 이 일치하지 않습니다.");
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -27,10 +27,10 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=https://kauth.k
 spring.cloud.aws.credentials.access-key=12345678910
 spring.cloud.aws.credentials.secret-key=12345678910
 spring.cloud.aws.region.static=ap-northeast-2
-spring.cloud.aws.s3.bucket: test-bucket
+spring.cloud.aws.s3.bucket=test-bucket
 ### Redis ###
 spring.data.redis.host=localhost
 spring.data.redis.port=6378
 ### JWT ###
 jwt.bearer=Bearer
-jwt.secret=secret
+jwt.secret=a2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRvsdsadwsadasdwSDSAweasDSadwXJsecretsecretsecretsecretsecreetsecret


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
기존 JWT 로직을 변경했으며, 인증,인가 로직 예외 처리를 추가 구현했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] JwtAuthenticationEntryPoint `401` 에러 응답으로 변경
- [x] JwtAuthorizationHandler `403` 에러 응답으로 변경
- [x] 기타 코드 수정 및 jwtservice 로직 변경
- [x] jwt 라이브러리 변경   

## 🦀 이슈 넘버

- close #101 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
