### PR TITLE
refactor: 기획 변경에 따른 회원 카드 등록 API 리팩토링

### DIFF
--- a/src/main/java/net/teumteum/user/domain/User.java
+++ b/src/main/java/net/teumteum/user/domain/User.java
@@ -54,8 +54,8 @@ public class User extends TimeBaseEntity {
     @Column(name = "role_type")
     private RoleType roleType;
 
-    @Embedded
-    private ActivityArea activityArea;
+    @Column(name = "activity_area")
+    private String activityArea;
 
     @Column(name = "mbti", length = 4)
     private String mbti;

--- a/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
@@ -4,6 +4,7 @@ import static net.teumteum.user.domain.RoleType.ROLE_USER;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -34,10 +35,11 @@ public record UserRegisterRequest(
     String mbti,
     @NotNull(message = "현재 상태는 필수 입력값입니다.")
     String status,
+    @Valid
     @NotNull(message = "직업 관련 값은 필수 입력값입니다.")
     Job job,
-    @Size(max = 3, message = "관심 항목은 최대 3개까지 입력가능합니다.")
     @NotEmpty(message = "관심 항목은 최소 1개을 입력해야합니다.")
+    @Size(max = 3, message = "관심 항목은 최대 3개까지 입력가능합니다.")
     List<String> interests,
     @Size(max = 50)
     @NotBlank(message = "목표는 필수 입력값입니다.")
@@ -77,8 +79,8 @@ public record UserRegisterRequest(
 
     @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public record Terms(
-        Boolean service,
-        Boolean privatePolicy
+        boolean service,
+        boolean privatePolicy
     ) {
 
     }

--- a/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
@@ -85,7 +85,7 @@ public record UserRegisterRequest(
 
     }
 
-
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public record Job(
         String name,
         @JsonProperty("class")

--- a/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserRegisterRequest.java
@@ -2,25 +2,45 @@ package net.teumteum.user.domain.request;
 
 import static net.teumteum.user.domain.RoleType.ROLE_USER;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.JobStatus;
 import net.teumteum.user.domain.OAuth;
 import net.teumteum.user.domain.User;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record UserRegisterRequest(
+    @NotBlank(message = "id 값은 필수 입력값입니다.")
     String id,
+    @NotNull(message = "동의 항목은 필수 입력값입니다.")
     Terms terms,
+    @NotBlank(message = "이름은 필수 입력값입니다.")
     String name,
+    @NotBlank(message = "생년월일은 필수 입력값입니다.")
     String birth,
+    @NotNull(message = "캐릭터 아이디는 필수 입력값입니다.")
     Long characterId,
+    @NotNull(message = "소셜 로그인 타입은 필수 입력값입니다.")
     Authenticated authenticated,
-    ActivityArea activityArea,
+    @NotBlank(message = "관심 지역은 필수 입력값입니다.")
+    String activityArea,
+    @NotBlank(message = "mbti 는 필수 입력값입니다.")
     String mbti,
+    @NotNull(message = "현재 상태는 필수 입력값입니다.")
     String status,
+    @NotNull(message = "직업 관련 값은 필수 입력값입니다.")
     Job job,
+    @Size(max = 3, message = "관심 항목은 최대 3개까지 입력가능합니다.")
+    @NotEmpty(message = "관심 항목은 최소 1개을 입력해야합니다.")
     List<String> interests,
+    @Size(max = 50)
+    @NotBlank(message = "목표는 필수 입력값입니다.")
     String goal
 ) {
 
@@ -36,10 +56,7 @@ public record UserRegisterRequest(
                 authenticated
             ),
             ROLE_USER,
-            new net.teumteum.user.domain.ActivityArea(
-                activityArea.city,
-                activityArea.street
-            ),
+            activityArea,
             mbti,
             JobStatus.valueOf(status),
             goal,
@@ -58,24 +75,21 @@ public record UserRegisterRequest(
         );
     }
 
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public record Terms(
-        boolean service,
-        boolean privatePolicy
+        Boolean service,
+        Boolean privatePolicy
     ) {
 
     }
 
-    public record ActivityArea(
-        String city,
-        List<String> street
-    ) {
-
-    }
 
     public record Job(
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         String name,
+        @JsonProperty("class")
+        @NotBlank(message = "직군은 필수 입력값입니다.")
         String jobClass,
+        @NotBlank(message = "직무는 필수 입력값입니다.")
         String detailClass
     ) {
 

--- a/src/main/java/net/teumteum/user/domain/request/UserUpdateRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserUpdateRequest.java
@@ -3,9 +3,12 @@ package net.teumteum.user.domain.request;
 import static net.teumteum.user.domain.RoleType.ROLE_USER;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Set;
-import net.teumteum.user.domain.ActivityArea;
 import net.teumteum.user.domain.Job;
 import net.teumteum.user.domain.JobStatus;
 import net.teumteum.user.domain.OAuth;
@@ -13,15 +16,27 @@ import net.teumteum.user.domain.Terms;
 import net.teumteum.user.domain.User;
 
 public record UserUpdateRequest(
+    @NotNull(message = "id 값은 필수 입력값입니다.")
     Long id,
+    @NotBlank(message = "이름은 필수 입력값입니다.")
     String newName,
+    @NotBlank(message = "생년월일은 필수 입력값입니다.")
     String newBirth,
+    @NotNull(message = "캐릭터 아이디는 필수 입력값입니다.")
     Long newCharacterId,
-    NewActivityArea newActivityArea,
+    @NotBlank(message = "관심 지역은 필수 입력값입니다.")
+    String newActivityArea,
+    @NotBlank(message = "mbti 는 필수 입력값입니다.")
     String newMbti,
+    @NotNull(message = "현재 상태는 필수 입력값입니다.")
     String newStatus,
+    @Size(max = 50)
+    @NotBlank(message = "목표는 필수 입력값입니다.")
     String newGoal,
+    @NotNull(message = "직업 관련 값은 필수 입력값입니다.")
     NewJob newJob,
+    @Size(max = 3, message = "관심 항목은 최대 3개까지 입력가능합니다.")
+    @NotEmpty(message = "관심 항목은 최소 1개을 입력해야합니다.")
     List<String> newInterests
 ) {
 
@@ -41,10 +56,7 @@ public record UserUpdateRequest(
             IGNORE_MANNER_TEMPERATURE,
             IGNORE_O_AUTH,
             ROLE_USER,
-            new ActivityArea(
-                newActivityArea.city,
-                newActivityArea.streets
-            ),
+            newActivityArea,
             newMbti,
             JobStatus.valueOf(newStatus),
             newGoal,
@@ -60,17 +72,13 @@ public record UserUpdateRequest(
         );
     }
 
-    public record NewActivityArea(
-        String city,
-        List<String> streets
-    ) {
-
-    }
-
     public record NewJob(
+
         String name,
         @JsonProperty("class")
+        @NotBlank(message = "직군은 필수 입력값입니다.")
         String jobClass,
+        @NotBlank(message = "직무는 필수 입력값입니다.")
         String detailClass
     ) {
 

--- a/src/main/java/net/teumteum/user/domain/request/UserUpdateRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserUpdateRequest.java
@@ -3,6 +3,7 @@ package net.teumteum.user.domain.request;
 import static net.teumteum.user.domain.RoleType.ROLE_USER;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -33,6 +34,7 @@ public record UserUpdateRequest(
     @Size(max = 50)
     @NotBlank(message = "목표는 필수 입력값입니다.")
     String newGoal,
+    @Valid
     @NotNull(message = "직업 관련 값은 필수 입력값입니다.")
     NewJob newJob,
     @Size(max = 3, message = "관심 항목은 최대 3개까지 입력가능합니다.")
@@ -73,7 +75,6 @@ public record UserUpdateRequest(
     }
 
     public record NewJob(
-
         String name,
         @JsonProperty("class")
         @NotBlank(message = "직군은 필수 입력값입니다.")

--- a/src/main/java/net/teumteum/user/domain/response/UserGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserGetResponse.java
@@ -2,7 +2,6 @@ package net.teumteum.user.domain.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.User;
 
@@ -13,7 +12,7 @@ public record UserGetResponse(
     Long characterId,
     int mannerTemperature,
     Authenticated authenticated,
-    ActivityArea activityArea,
+    String activityArea,
     String mbti,
     String status,
     String goal,
@@ -29,7 +28,7 @@ public record UserGetResponse(
             user.getCharacterId(),
             user.getMannerTemperature(),
             user.getOauth().getAuthenticated(),
-            ActivityArea.of(user),
+            user.getActivityArea(),
             user.getMbti(),
             user.getStatus().name(),
             user.getGoal(),
@@ -38,19 +37,6 @@ public record UserGetResponse(
         );
     }
 
-    public record ActivityArea(
-        String city,
-        List<String> streets
-    ) {
-
-        public static ActivityArea of(User user) {
-            return new ActivityArea(
-                user.getActivityArea().getCity(),
-                user.getActivityArea().getStreet()
-            );
-        }
-
-    }
 
     public record Job(
         String name,

--- a/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
@@ -6,9 +6,20 @@ import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.User;
 
 
-public record UserMeGetResponse(Long id, String name, String birth, Long characterId, int mannerTemperature,
-                                Authenticated authenticated, String activityArea, String mbti, String status,
-                                String goal, Job job, List<String> interests) {
+public record UserMeGetResponse(
+    Long id,
+    String name,
+    String birth,
+    Long characterId,
+    int mannerTemperature,
+    Authenticated authenticated,
+    String activityArea,
+    String mbti,
+    String status,
+    String goal,
+    Job job,
+    List<String> interests
+) {
 
     public static UserMeGetResponse of(User user) {
         return new UserMeGetResponse(user.getId(), user.getName(), user.getBirth(), user.getCharacterId(),

--- a/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
@@ -1,73 +1,27 @@
 package net.teumteum.user.domain.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.User;
 
 
-import java.util.List;
-
-public record UserMeGetResponse(
-        Long id,
-        String name,
-        String birth,
-        Long characterId,
-        int mannerTemperature,
-        Authenticated authenticated,
-        ActivityArea activityArea,
-        String mbti,
-        String status,
-        String goal,
-        Job job,
-        List<String> interests
-) {
+public record UserMeGetResponse(Long id, String name, String birth, Long characterId, int mannerTemperature,
+                                Authenticated authenticated, String activityArea, String mbti, String status,
+                                String goal, Job job, List<String> interests) {
 
     public static UserMeGetResponse of(User user) {
-        return new UserMeGetResponse(
-                user.getId(),
-                user.getName(),
-                user.getBirth(),
-                user.getCharacterId(),
-                user.getMannerTemperature(),
-                user.getOauth().getAuthenticated(),
-                ActivityArea.of(user),
-                user.getMbti(),
-                user.getStatus().name(),
-                user.getGoal(),
-                Job.of(user),
-                user.getInterests()
-        );
+        return new UserMeGetResponse(user.getId(), user.getName(), user.getBirth(), user.getCharacterId(),
+            user.getMannerTemperature(), user.getOauth().getAuthenticated(), user.getActivityArea(), user.getMbti(),
+            user.getStatus().name(), user.getGoal(), Job.of(user), user.getInterests());
     }
 
-    public record ActivityArea(
-            String city,
-            List<String> streets
-    ) {
 
-        public static ActivityArea of(User user) {
-            return new ActivityArea(
-                    user.getActivityArea().getCity(),
-                    user.getActivityArea().getStreet()
-            );
-        }
-
-    }
-
-    public record Job(
-            String name,
-            boolean certificated,
-            @JsonProperty("class")
-            String jobClass,
-            String detailClass
-    ) {
+    public record Job(String name, boolean certificated, @JsonProperty("class") String jobClass, String detailClass) {
 
         public static Job of(User user) {
-            return new Job(
-                    user.getJob().getName(),
-                    user.getJob().isCertificated(),
-                    user.getJob().getJobClass(),
-                    user.getJob().getDetailJobClass()
-            );
+            return new Job(user.getJob().getName(), user.getJob().isCertificated(), user.getJob().getJobClass(),
+                user.getJob().getDetailJobClass());
         }
     }
 }

--- a/src/main/java/net/teumteum/user/domain/response/UsersGetByIdResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UsersGetByIdResponse.java
@@ -2,7 +2,6 @@ package net.teumteum.user.domain.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.User;
 
@@ -24,7 +23,7 @@ public record UsersGetByIdResponse(
         Long characterId,
         int mannerTemperature,
         Authenticated authenticated,
-        ActivityArea activityArea,
+        String activityArea,
         String mbti,
         String status,
         String goal,
@@ -40,27 +39,13 @@ public record UsersGetByIdResponse(
                 user.getCharacterId(),
                 user.getMannerTemperature(),
                 user.getOauth().getAuthenticated(),
-                ActivityArea.of(user),
+                user.getActivityArea(),
                 user.getMbti(),
                 user.getStatus().name(),
                 user.getGoal(),
                 Job.of(user),
                 user.getInterests()
             );
-        }
-
-        public record ActivityArea(
-            String city,
-            List<String> streets
-        ) {
-
-            public static ActivityArea of(User user) {
-                return new ActivityArea(
-                    user.getActivityArea().getCity(),
-                    user.getActivityArea().getStreet()
-                );
-            }
-
         }
 
         public record Job(

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -85,7 +85,6 @@ public class UserService {
 
     @Transactional
     public void logout(Long userId) {
-        getUser(userId);
         redisService.deleteData(String.valueOf(userId));
         SecurityService.clearSecurityContext();
     }

--- a/src/main/resources/db/migration/V5__update_users.sql
+++ b/src/main/resources/db/migration/V5__update_users.sql
@@ -1,0 +1,8 @@
+drop table users_interests;
+
+alter table users
+    drop column city;
+
+alter table users
+    add column activity_area varchar(255);
+

--- a/src/test/java/net/teumteum/integration/RequestFixture.java
+++ b/src/test/java/net/teumteum/integration/RequestFixture.java
@@ -2,53 +2,55 @@ package net.teumteum.integration;
 
 import java.util.UUID;
 import net.teumteum.core.security.Authenticated;
-import net.teumteum.user.domain.Job;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.request.UserRegisterRequest;
-import net.teumteum.user.domain.request.UserRegisterRequest.ActivityArea;
+import net.teumteum.user.domain.request.UserRegisterRequest.Job;
 import net.teumteum.user.domain.request.UserRegisterRequest.Terms;
 import net.teumteum.user.domain.request.UserUpdateRequest;
-import net.teumteum.user.domain.request.UserUpdateRequest.NewActivityArea;
 import net.teumteum.user.domain.request.UserUpdateRequest.NewJob;
 
 public class RequestFixture {
 
     public static UserUpdateRequest userUpdateRequest(User user) {
         return new UserUpdateRequest(user.getId(), "new_name", user.getBirth(), user.getCharacterId(),
-            newActivityArea(user), user.getMbti(), user.getStatus().name(), user.getGoal(), newJob(user),
+            user.getActivityArea(), user.getMbti(), user.getStatus().name(), user.getGoal(), newJob(user),
             user.getInterests());
-    }
-
-    private static NewActivityArea newActivityArea(User user) {
-        return new NewActivityArea(user.getActivityArea().getCity(), user.getActivityArea().getStreet());
     }
 
     private static NewJob newJob(User user) {
         return new NewJob(user.getJob().getName(), user.getJob().getJobClass(), user.getJob().getDetailJobClass());
     }
 
+
     public static UserRegisterRequest userRegisterRequest(User user) {
         return new UserRegisterRequest(UUID.randomUUID().toString(),
-            new Terms(user.getTerms().getService(), user.getTerms().getPrivacyPolicy()), user.getName(),
-            user.getBirth(), user.getCharacterId(), Authenticated.카카오, activityArea(user),
-            user.getMbti(), user.getStatus().name(), new UserRegisterRequest.Job("직장인", "디자인", "BX 디자이너"),
+            terms(user), user.getName(),
+            user.getBirth(), user.getCharacterId(), Authenticated.카카오, user.getActivityArea(),
+            user.getMbti(), user.getStatus().name(), job(user),
             user.getInterests(), user.getGoal());
     }
 
     public static UserRegisterRequest userRegisterRequestWithFail(User user) {
         return new UserRegisterRequest(user.getOauth().getOauthId(),
-            new Terms(user.getTerms().getService(), user.getTerms().getPrivacyPolicy()), user.getName(),
-            user.getBirth(), user.getCharacterId(), user.getOauth().getAuthenticated(), activityArea(user),
-            user.getMbti(), user.getStatus().name(), new UserRegisterRequest.Job("직장인", "디자인", "BX 디자이너"),
+            terms(user), user.getName(),
+            user.getBirth(), user.getCharacterId(), user.getOauth().getAuthenticated(), user.getActivityArea(),
+            user.getMbti(), user.getStatus().name(), job(user),
             user.getInterests(), user.getGoal());
     }
 
-    private static ActivityArea activityArea(User user) {
-        return new ActivityArea(user.getActivityArea().getCity(), user.getActivityArea().getStreet());
+    public static UserRegisterRequest userRegisterRequestWithNoValid(User user) {
+        return new UserRegisterRequest(user.getOauth().getOauthId(),
+            terms(user), null,
+            user.getBirth(), user.getCharacterId(), user.getOauth().getAuthenticated(), user.getActivityArea(),
+            user.getMbti(), user.getStatus().name(), job(user),
+            null, user.getGoal());
     }
 
     private static Job job(User user) {
-        return new Job(user.getJob().getName(), false, user.getJob().getJobClass(), user.getJob().getDetailJobClass());
+        return new Job(user.getJob().getName(), user.getJob().getJobClass(), user.getJob().getDetailJobClass());
     }
 
+    private static Terms terms(User user) {
+        return new Terms(user.getTerms().getService(), user.getTerms().getPrivacyPolicy());
+    }
 }

--- a/src/test/java/net/teumteum/integration/RequestFixture.java
+++ b/src/test/java/net/teumteum/integration/RequestFixture.java
@@ -47,7 +47,9 @@ public class RequestFixture {
     }
 
     private static Job job(User user) {
-        return new Job(user.getJob().getName(), user.getJob().getJobClass(), user.getJob().getDetailJobClass());
+        return new Job(user.getJob().getName(),
+            user.getJob().getJobClass(),
+            user.getJob().getDetailJobClass());
     }
 
     private static Terms terms(User user) {

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -319,8 +319,7 @@ class UserIntegrationTest extends IntegrationTest {
                 .expectBody(ErrorResponse.class)
                 .returnResult().getResponseBody();
 
-            Assertions.assertThat(responseBody)
-                .isNotNull();
+            Assertions.assertThat(responseBody).isNull();
         }
     }
 

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -2,16 +2,18 @@ package net.teumteum.integration;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.util.List;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.response.FriendsResponse;
+import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UserMeGetResponse;
-import net.teumteum.user.domain.response.*;
+import net.teumteum.user.domain.response.UserRegisterResponse;
+import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 @DisplayName("유저 통합테스트의")
 class UserIntegrationTest extends IntegrationTest {
@@ -125,10 +127,10 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             Assertions.assertThat(result.expectStatus().isOk()
-                            .expectBody(UserMeGetResponse.class)
-                            .returnResult()
-                            .getResponseBody())
-                    .usingRecursiveComparison().isEqualTo(expected);
+                    .expectBody(UserMeGetResponse.class)
+                    .returnResult()
+                    .getResponseBody())
+                .usingRecursiveComparison().isEqualTo(expected);
         }
 
     }
@@ -295,6 +297,25 @@ class UserIntegrationTest extends IntegrationTest {
 
             // then
             var responseBody = result.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult().getResponseBody();
+
+            Assertions.assertThat(responseBody)
+                .isNotNull();
+        }
+
+        @Test
+        @DisplayName("요청 값의 유효성 검사가 실패하면, 400 에러를 반환한다.")
+        void Return_400_badRequest_if_not_meet_request_condition() {
+            // given
+            var existUser = repository.saveAndGetUser();
+
+            var userRegister = RequestFixture.userRegisterRequestWithNoValid(existUser);
+            // when
+            var result = api.registerUserCard(VALID_TOKEN, userRegister);
+
+            // then
+            ErrorResponse responseBody = result.expectStatus().isBadRequest()
                 .expectBody(ErrorResponse.class)
                 .returnResult().getResponseBody();
 

--- a/src/test/java/net/teumteum/unit/auth/common/SecurityValue.java
+++ b/src/test/java/net/teumteum/unit/auth/common/SecurityValue.java
@@ -1,0 +1,12 @@
+package net.teumteum.unit.auth.common;
+
+public final class SecurityValue {
+
+    public static final String VALID_ACCESS_TOKEN = "VALID_ACCESS_TOKEN";
+    public static final String INVALID_ACCESS_TOKEN = "INVALID_ACCESS_TOKEN";
+    public static final String VALID_REFRESH_TOKEN = "VALID_REFRESH_TOKEN";
+    public static final String INVALID_REFRESH_TOKEN = "INVALID_REFRESH_TOKEN";
+
+    private SecurityValue() {
+    }
+}

--- a/src/test/java/net/teumteum/unit/auth/controller/AuthControllerTest.java
+++ b/src/test/java/net/teumteum/unit/auth/controller/AuthControllerTest.java
@@ -1,6 +1,10 @@
 package net.teumteum.unit.auth.controller;
 
 
+import static net.teumteum.unit.auth.common.SecurityValue.INVALID_ACCESS_TOKEN;
+import static net.teumteum.unit.auth.common.SecurityValue.INVALID_REFRESH_TOKEN;
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -39,11 +43,6 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("인증 컨트롤러 단위 테스트의")
 public class AuthControllerTest {
 
-    private static final String VALID_ACCESS_TOKEN = "VALID_ACCESS_TOKEN";
-    private static final String INVALID_ACCESS_TOKEN = "INVALID_ACCESS_TOKEN";
-    private static final String VALID_REFRESH_TOKEN = "VALID_REFRESH_TOKEN";
-    private static final String INVALID_REFRESH_TOKEN = "INVALID_REFRESH_TOKEN";
-
     @Autowired
     private MockMvc mockMvc;
 
@@ -58,7 +57,7 @@ public class AuthControllerTest {
         @DisplayName("유효하지 않은 access token 과 유효한 refresh token 이 주어지면, 새로운 토큰을 발급한다.")
         void Return_new_jwt_if_access_and_refresh_is_exist() throws Exception {
             // given
-            TokenResponse tokenResponse = new TokenResponse(INVALID_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
+            TokenResponse tokenResponse = new TokenResponse(VALID_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
 
             given(authService.reissue(any(HttpServletRequest.class))).willReturn(tokenResponse);
             // when & then

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -101,7 +101,7 @@ public class UserControllerTest {
                     .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("이름은 필수 입력값입니다."));
+                .andExpect(jsonPath("$.message").isNotEmpty());
         }
     }
 }

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -1,0 +1,107 @@
+package net.teumteum.unit.user.controller;
+
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.teumteum.core.security.SecurityConfig;
+import net.teumteum.core.security.filter.JwtAuthenticationFilter;
+import net.teumteum.core.security.service.JwtService;
+import net.teumteum.core.security.service.RedisService;
+import net.teumteum.core.security.service.SecurityService;
+import net.teumteum.integration.RequestFixture;
+import net.teumteum.user.controller.UserController;
+import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.UserFixture;
+import net.teumteum.user.domain.request.UserRegisterRequest;
+import net.teumteum.user.domain.response.UserRegisterResponse;
+import net.teumteum.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(value = UserController.class,
+    excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RedisService.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtService.class)}
+)
+@WithMockUser
+@DisplayName("유저 컨트롤러 단위 테스트의")
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private SecurityService securityService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserFixture.getIdUser();
+    }
+
+    @Nested
+    @DisplayName("유저 카드 등록 API는")
+    class Register_user_card_api_unit {
+
+        @Test
+        @DisplayName("유효한 사용자의 등록 요청값이 주어지면, 201 Created 상태값을 반환한다.")
+        void Register_user_card_with_201_created() throws Exception {
+            // given
+            UserRegisterRequest request = RequestFixture.userRegisterRequest(user);
+
+            UserRegisterResponse response = new UserRegisterResponse(1L);
+
+            given(userService.register(any(UserRegisterRequest.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/users")
+                    .content(new ObjectMapper().writeValueAsString(request))
+                    .contentType(APPLICATION_JSON)
+                    .with(csrf())
+                    .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 사용자의 등록 요청값이 주어지면, 400 Bad Request 상태값을 반환한다.")
+        void Register_user_card_with_400_bad_request() throws Exception {
+            // given
+            UserRegisterRequest request = RequestFixture.userRegisterRequestWithNoValid(user);
+            // when
+            // then
+            mockMvc.perform(post("/users")
+                    .content(new ObjectMapper().writeValueAsString(request))
+                    .contentType(APPLICATION_JSON)
+                    .with(csrf())
+                    .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이름은 필수 입력값입니다."));
+        }
+    }
+}

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -1,0 +1,78 @@
+package net.teumteum.unit.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import net.teumteum.core.security.service.RedisService;
+import net.teumteum.integration.RequestFixture;
+import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.UserFixture;
+import net.teumteum.user.domain.UserRepository;
+import net.teumteum.user.domain.request.UserRegisterRequest;
+import net.teumteum.user.domain.response.UserRegisterResponse;
+import net.teumteum.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("유저 서비스 단위 테스트의")
+public class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    RedisService redisService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserFixture.getIdUser();
+    }
+
+    @Nested
+    @DisplayName("유저 카드 등록 API는")
+    class Register_user_card_api_unit {
+
+        @Test
+        @DisplayName("유효한 유저의 요청 값이 들어오는 경우, 정상적으로 유저 카드를 등록한다.")
+        void If_valid_user_request_register_user_card() {
+            // given
+            UserRegisterRequest request = RequestFixture.userRegisterRequest(user);
+
+            given(userRepository.save(any(User.class))).willReturn(user);
+
+            // when
+            UserRegisterResponse response = userService.register(request);
+
+            // then
+            assertThat(response.id()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("사용자가 이미 존재하면, 카드 등록을 실패한다.")
+        void If_user_already_exist_register_user_card_fail() {
+            // given
+            UserRegisterRequest request = RequestFixture.userRegisterRequestWithFail(user);
+
+            given(userRepository.findByAuthenticatedAndOAuthId(any(), any()))
+                .willThrow(new IllegalArgumentException("일치하는 user 가 이미 존재합니다."));
+
+            assertThatThrownBy(() -> userService.register(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("일치하는 user 가 이미 존재합니다.");
+        }
+    }
+}

--- a/src/test/java/net/teumteum/user/domain/UserFixture.java
+++ b/src/test/java/net/teumteum/user/domain/UserFixture.java
@@ -1,31 +1,30 @@
 package net.teumteum.user.domain;
 
-import lombok.Builder;
+import static net.teumteum.core.security.Authenticated.네이버;
 
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
-import static net.teumteum.core.security.Authenticated.네이버;
+import lombok.Builder;
 
 public class UserFixture {
 
     public static User getNullIdUser() {
         return newUserByBuilder(UserBuilder.builder()
-                .id(null)
-                .build());
+            .id(null)
+            .build());
     }
 
     public static User getIdUser() {
         return newUserByBuilder(UserBuilder.builder()
-                .id(1L)
-                .build());
+            .id(1L)
+            .build());
     }
 
     public static User getUserWithId(Long id) {
         return newUserByBuilder(UserBuilder.builder()
-                .id(id)
-                .build());
+            .id(id)
+            .build());
     }
 
     public static User getDefaultUser() {
@@ -34,21 +33,21 @@ public class UserFixture {
 
     public static User newUserByBuilder(UserBuilder userBuilder) {
         return new User(
-                userBuilder.id,
-                userBuilder.name,
-                userBuilder.birth,
-                userBuilder.characterId,
-                userBuilder.mannerTemperature,
-                userBuilder.oauth,
-                userBuilder.roleType,
-                userBuilder.activityArea,
-                userBuilder.mbti,
-                userBuilder.status,
-                userBuilder.goal,
-                userBuilder.job,
-                userBuilder.interests,
-                userBuilder.terms,
-                Set.of()
+            userBuilder.id,
+            userBuilder.name,
+            userBuilder.birth,
+            userBuilder.characterId,
+            userBuilder.mannerTemperature,
+            userBuilder.oauth,
+            userBuilder.roleType,
+            userBuilder.activityArea,
+            userBuilder.mbti,
+            userBuilder.status,
+            userBuilder.goal,
+            userBuilder.job,
+            userBuilder.interests,
+            userBuilder.terms,
+            Set.of()
         );
     }
 
@@ -70,7 +69,7 @@ public class UserFixture {
         @Builder.Default
         private RoleType roleType = RoleType.ROLE_USER;
         @Builder.Default
-        private ActivityArea activityArea = new ActivityArea("서울", List.of("강남", "홍대"));
+        private String activityArea = "서울 강남";
         @Builder.Default
         private String mbti = "ESFP";
         @Builder.Default
@@ -81,7 +80,7 @@ public class UserFixture {
         private Job job = new Job("netflix", true, "developer", "backend");
         @Builder.Default
         private List<String> interests = List.of(
-                "game", "sleep", "Eating delicious food"
+            "game", "sleep", "Eating delicious food"
         );
         @Builder.Default
         private Terms terms = new Terms(true, true);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,6 +1,6 @@
 create table if not exists users
 (
-    id                 bigint       not null auto_increment,
+    id                 bigint             not null auto_increment,
     certificated       boolean,
     manner_temperature integer,
     mbti               varchar(4),
@@ -8,18 +8,18 @@ create table if not exists users
     birth              varchar(10),
     name               varchar(10),
     goal               varchar(50),
-    oauth_id           varchar(255) not null unique,
+    oauth_id           varchar(255)       not null unique,
     authenticated      enum ('카카오','네이버') not null,
     role_type          enum ('ROLE_USER','ROLE_ADMIN'),
-    city               varchar(255),
+    activity_area      varchar(255),
     detail_job_class   varchar(255),
     job_class          varchar(255),
     job_name           varchar(255),
     status             enum ('직장인','학생','취업준비생'),
-    terms_of_service   boolean      not null,
-    privacy_policy     boolean      not null,
-    created_at         timestamp(6) not null,
-    updated_at         timestamp(6) not null,
+    terms_of_service   boolean            not null,
+    privacy_policy     boolean            not null,
+    created_at         timestamp(6)       not null,
+    updated_at         timestamp(6)       not null,
     primary key (id)
 );
 
@@ -30,12 +30,6 @@ create table if not exists users_interests
     foreign key (users_id) references users (id)
 );
 
-create table if not exists users_street
-(
-    users_id bigint not null,
-    street   varchar(255),
-    foreign key (users_id) references users (id)
-);
 
 create table if not exists meeting
 (


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
기존 `city` , `street` 을 하나의 객체로 받는 방식 -> `activityArea` 문자열 하나로 받는 방식으로 기획 변경, 기존 API 수정 및 요청,응답 객체 변경

## 🕶️ 어떻게 해결했나요?
- [x] 회원 카드 등록 API 리팩토링
- [x] 관련 DTO 및 VO 리팩토링
- [x] 통합 테스트 수정 및 단위 테스트 작성
- [x] 기타 코드 리팩토링   

## 🦀 이슈 넘버
- close #104 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
<img width="960" alt="스크린샷 2024-01-17 오전 7 11 13" src="https://github.com/depromeet/teum-teum-server/assets/96874318/3e647d30-ded7-4a10-bff5-019c810311f3">

