### PR TITLE
refactor: 회원 카드 등록시 JWT 정보도 함께 반환하도록 수정

### DIFF
--- a/src/main/java/net/teumteum/user/domain/response/UserRegisterResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserRegisterResponse.java
@@ -1,7 +1,14 @@
 package net.teumteum.user.domain.response;
 
+import net.teumteum.auth.domain.response.TokenResponse;
+
 public record UserRegisterResponse(
-    Long id
+    Long id,
+    String accessToken,
+    String refreshToken
 ) {
 
+    public static UserRegisterResponse of(Long id, TokenResponse tokenResponse) {
+        return new UserRegisterResponse(id, tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+    }
 }

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -3,6 +3,7 @@ package net.teumteum.user.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.security.Authenticated;
+import net.teumteum.core.security.service.JwtService;
 import net.teumteum.core.security.service.RedisService;
 import net.teumteum.core.security.service.SecurityService;
 import net.teumteum.user.domain.BalanceGameType;
@@ -29,6 +30,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final InterestQuestion interestQuestion;
     private final RedisService redisService;
+    private final JwtService jwtService;
 
     public UserGetResponse getUserById(Long userId) {
         var existUser = getUser(userId);
@@ -79,8 +81,9 @@ public class UserService {
     @Transactional
     public UserRegisterResponse register(UserRegisterRequest request) {
         checkUserExistence(request.authenticated(), request.id());
+        User savedUser = userRepository.save(request.toUser());
 
-        return new UserRegisterResponse(userRepository.save(request.toUser()).getId());
+        return UserRegisterResponse.of(savedUser.getId(), jwtService.createServiceToken(savedUser));
     }
 
     @Transactional

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import java.util.List;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.UserFixture;
 import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UserMeGetResponse;
@@ -271,9 +272,7 @@ class UserIntegrationTest extends IntegrationTest {
         @DisplayName("등록할 회원의 정보가 주어지면, 회원 정보를 저장한다.")
         void Register_user_info() {
             // given
-            var additionalUser = repository.saveAndGetUser();
-
-            var UserRegister = RequestFixture.userRegisterRequest(additionalUser);
+            var UserRegister = RequestFixture.userRegisterRequest(UserFixture.getIdUser());
             // when
             var result = api.registerUserCard(VALID_TOKEN, UserRegister);
 

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package net.teumteum.unit.user.controller;
 
 import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -72,7 +73,7 @@ public class UserControllerTest {
             // given
             UserRegisterRequest request = RequestFixture.userRegisterRequest(user);
 
-            UserRegisterResponse response = new UserRegisterResponse(1L);
+            UserRegisterResponse response = new UserRegisterResponse(1L, VALID_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
 
             given(userService.register(any(UserRegisterRequest.class))).willReturn(response);
 
@@ -84,7 +85,9 @@ public class UserControllerTest {
                     .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
                 .andDo(print())
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1));
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.accessToken").value(VALID_ACCESS_TOKEN))
+                .andExpect(jsonPath("$.refreshToken").value(VALID_REFRESH_TOKEN));
         }
 
         @Test

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -1,10 +1,14 @@
 package net.teumteum.unit.user.service;
 
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import net.teumteum.auth.domain.response.TokenResponse;
+import net.teumteum.core.security.service.JwtService;
 import net.teumteum.core.security.service.RedisService;
 import net.teumteum.integration.RequestFixture;
 import net.teumteum.user.domain.User;
@@ -35,6 +39,9 @@ public class UserServiceTest {
     @Mock
     RedisService redisService;
 
+    @Mock
+    JwtService jwtService;
+
     private User user;
 
     @BeforeEach
@@ -51,14 +58,21 @@ public class UserServiceTest {
         void If_valid_user_request_register_user_card() {
             // given
             UserRegisterRequest request = RequestFixture.userRegisterRequest(user);
+            TokenResponse tokenResponse = new TokenResponse(VALID_ACCESS_TOKEN, VALID_REFRESH_TOKEN);
+
+            UserRegisterResponse response = UserRegisterResponse.of(1L, tokenResponse);
 
             given(userRepository.save(any(User.class))).willReturn(user);
 
+            given(jwtService.createServiceToken(any(User.class))).willReturn(tokenResponse);
+
             // when
-            UserRegisterResponse response = userService.register(request);
+            UserRegisterResponse result = userService.register(request);
 
             // then
             assertThat(response.id()).isEqualTo(1);
+            assertThat(response.accessToken()).isNotNull();
+            assertThat(response.refreshToken()).isNotNull();
         }
 
         @Test

--- a/src/test/java/net/teumteum/user/domain/UserFixture.java
+++ b/src/test/java/net/teumteum/user/domain/UserFixture.java
@@ -59,7 +59,7 @@ public class UserFixture {
         @Builder.Default
         private String name = "Jennifer";
         @Builder.Default
-        private String birth = "2000.02.05";
+        private String birth = "20000205";
         @Builder.Default
         private Long characterId = 1L;
         @Builder.Default

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -34,3 +34,7 @@ spring.data.redis.port=6378
 ### JWT ###
 jwt.bearer=Bearer
 jwt.secret=a2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRvsdsadwsadasdwSDSAweasDSadwXJsecretsecretsecretsecretsecreetsecret
+jwt.access.header=Authorization
+jwt.access.expiration=3600000
+jwt.refresh.expiration=3600000
+jwt.refresh.header=Authorization-refresh


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?

회원 카드 등록 API 수정 

## 🕶️ 어떻게 해결했나요?
- [x] UserRegisterResponse 응답 레코드에 JWT  필드 추가
- [x] API 수정
- [x] 테스트 코드 수정  

## 🦀 이슈 넘버

- close #113 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->


## 참고자료
<img width="983" alt="스크린샷 2024-01-18 오전 9 11 54" src="https://github.com/depromeet/teum-teum-server/assets/96874318/e5c7ba51-8c41-497d-b1ac-c09f140bfe9e">

