### PR TITLE
fix: 모임 목록 조회 조건에 활동 지역 조건이 안걸리는 버그 수정

### DIFF
--- a/src/main/java/net/teumteum/meeting/controller/MeetingController.java
+++ b/src/main/java/net/teumteum/meeting/controller/MeetingController.java
@@ -52,7 +52,7 @@ public class MeetingController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public PageDto<MeetingsResponse> getMeetingsOrderByDate(
+    public PageDto<MeetingsResponse> getMeetingsByCondition(
         Pageable pageable,
         @RequestParam(value = "isOpen") boolean isOpen,
         @RequestParam(value = "topic", required = false) Topic topic,

--- a/src/main/java/net/teumteum/meeting/service/MeetingService.java
+++ b/src/main/java/net/teumteum/meeting/service/MeetingService.java
@@ -83,7 +83,7 @@ public class MeetingService {
         if (topic != null) {
             spec = spec.and(MeetingSpecification.withTopic(topic));
         } else if (meetingAreaStreet != null) {
-            spec.and(MeetingSpecification.withAreaStreet(meetingAreaStreet));
+            spec = spec.and(MeetingSpecification.withAreaStreet(meetingAreaStreet));
         } else if (participantUserId != null) {
             spec = spec.and(MeetingSpecification.withParticipantUserId(participantUserId));
         } else if (searchWord != null) {


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
모임 목록 조회 조건에 활동 지역 조건이 안걸리는 버그 수정

## 🕶️ 어떻게 해결했나요?
조건을 걸리도록 변경

## 🦀 이슈 넘버
#120 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
