### PR TITLE
feat: 회원 탈퇴 사유 저장 로직 추가 및 cors 관련 재설정

### DIFF
--- a/src/main/java/net/teumteum/core/security/SecurityConfig.java
+++ b/src/main/java/net/teumteum/core/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable).cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(request -> request.requestMatchers(PATTERNS).permitAll()
-                .requestMatchers(HttpMethod.POST, "/users/registers").permitAll()
+                .requestMatchers(HttpMethod.POST, "/users").permitAll()
                 .anyRequest().authenticated()).httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(STATELESS))
@@ -64,7 +64,7 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedOrigin("*");
         config.addAllowedHeader("*");
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.addExposedHeader("Authorization");

--- a/src/main/java/net/teumteum/meeting/domain/Meeting.java
+++ b/src/main/java/net/teumteum/meeting/domain/Meeting.java
@@ -1,6 +1,21 @@
 package net.teumteum.meeting.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,16 +23,11 @@ import lombok.NoArgsConstructor;
 import net.teumteum.core.entity.TimeBaseEntity;
 import org.springframework.util.Assert;
 
-import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-@Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@Entity(name = "meetings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting extends TimeBaseEntity {
 
     @Id

--- a/src/main/java/net/teumteum/meeting/domain/Meeting.java
+++ b/src/main/java/net/teumteum/meeting/domain/Meeting.java
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
 @Getter
 @Builder
 @AllArgsConstructor
-@Entity(name = "meetings")
+@Entity(name = "meeting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting extends TimeBaseEntity {
 

--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -21,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -88,7 +87,7 @@ public class UserController {
         return userService.getInterestQuestionByUserIds(userIds, balance);
     }
 
-    @DeleteMapping
+    @PostMapping("/withdraw")
     @ResponseStatus(HttpStatus.OK)
     public void withdraw(@Valid @RequestBody UserWithdrawRequest request) {
         userService.withdraw(request, getCurrentUserId());

--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -9,6 +9,7 @@ import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.core.security.service.SecurityService;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserUpdateRequest;
+import net.teumteum.user.domain.request.UserWithdrawRequest;
 import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.InterestQuestionResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
@@ -89,8 +90,8 @@ public class UserController {
 
     @DeleteMapping
     @ResponseStatus(HttpStatus.OK)
-    public void withdraw() {
-        userService.withdraw(getCurrentUserId());
+    public void withdraw(@Valid @RequestBody UserWithdrawRequest request) {
+        userService.withdraw(request, getCurrentUserId());
     }
 
     @PostMapping

--- a/src/main/java/net/teumteum/user/domain/User.java
+++ b/src/main/java/net/teumteum/user/domain/User.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,9 +25,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.util.Assert;
 
 @Getter
-@Entity(name = "users")
-@NoArgsConstructor
 @AllArgsConstructor
+@Entity(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends TimeBaseEntity {
 
     @Id

--- a/src/main/java/net/teumteum/user/domain/WithdrawReason.java
+++ b/src/main/java/net/teumteum/user/domain/WithdrawReason.java
@@ -1,0 +1,26 @@
+package net.teumteum.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.teumteum.core.entity.TimeBaseEntity;
+
+@Getter
+@AllArgsConstructor
+@Entity(name = "withdraw_reasons")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawReason extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "withdraw_reason", nullable = false)
+    private String reason;
+}

--- a/src/main/java/net/teumteum/user/domain/WithdrawReasonRepository.java
+++ b/src/main/java/net/teumteum/user/domain/WithdrawReasonRepository.java
@@ -1,0 +1,7 @@
+package net.teumteum.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawReasonRepository extends JpaRepository<WithdrawReason, Long> {
+
+}

--- a/src/main/java/net/teumteum/user/domain/request/UserWithdrawRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserWithdrawRequest.java
@@ -1,0 +1,20 @@
+package net.teumteum.user.domain.request;
+
+
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import net.teumteum.user.domain.WithdrawReason;
+
+public record UserWithdrawRequest(
+    @Size(min = 1, max = 3, message = "탈퇴 사유는 최소 1개, 최대 3개의 입력값입니다.")
+    List<String> withdrawReasons
+) {
+
+    private static final Long IGNORE_ID = null;
+
+    public List<WithdrawReason> toEntity() {
+        return withdrawReasons.stream()
+            .map(withdrawReason -> new WithdrawReason(IGNORE_ID, withdrawReason))
+            .toList();
+    }
+}

--- a/src/main/java/net/teumteum/user/domain/request/UserWithdrawRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/UserWithdrawRequest.java
@@ -1,10 +1,12 @@
 package net.teumteum.user.domain.request;
 
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import net.teumteum.user.domain.WithdrawReason;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public record UserWithdrawRequest(
     @Size(min = 1, max = 3, message = "탈퇴 사유는 최소 1개, 최대 3개의 입력값입니다.")
     List<String> withdrawReasons

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -10,8 +10,10 @@ import net.teumteum.user.domain.BalanceGameType;
 import net.teumteum.user.domain.InterestQuestion;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserRepository;
+import net.teumteum.user.domain.WithdrawReasonRepository;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserUpdateRequest;
+import net.teumteum.user.domain.request.UserWithdrawRequest;
 import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.InterestQuestionResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
@@ -28,6 +30,7 @@ import org.springframework.util.Assert;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final WithdrawReasonRepository withdrawReasonRepository;
     private final InterestQuestion interestQuestion;
     private final RedisService redisService;
     private final JwtService jwtService;
@@ -71,11 +74,13 @@ public class UserService {
     }
 
     @Transactional
-    public void withdraw(Long userId) {
+    public void withdraw(UserWithdrawRequest request, Long userId) {
         var existUser = getUser(userId);
 
         userRepository.delete(existUser);
         redisService.deleteData(String.valueOf(userId));
+
+        withdrawReasonRepository.saveAll(request.toEntity());
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V7__create_withdraw_reason.sql
+++ b/src/main/resources/db/migration/V7__create_withdraw_reason.sql
@@ -1,0 +1,8 @@
+create table if not exists withdraw_reason
+(
+    id              bigint       not null auto_increment,
+    withdraw_reason varchar(30)  not null,
+    created_at      timestamp(6) not null,
+    updated_at      timestamp(6) not null,
+    primary key (id)
+);

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -6,6 +6,7 @@ import net.teumteum.meeting.domain.Topic;
 import net.teumteum.teum_teum.domain.request.UserLocationRequest;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserUpdateRequest;
+import net.teumteum.user.domain.request.UserWithdrawRequest;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Pageable;
@@ -129,10 +130,12 @@ class Api {
             .exchange();
     }
 
-    ResponseSpec withdrawUser(String accessToken) {
-        return webTestClient.delete()
-            .uri("/users")
+    ResponseSpec withdrawUser(String accessToken, UserWithdrawRequest request) {
+        return webTestClient
+            .post()
+            .uri("/users/withdraw")
             .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .bodyValue(request)
             .exchange();
     }
 

--- a/src/test/java/net/teumteum/integration/RequestFixture.java
+++ b/src/test/java/net/teumteum/integration/RequestFixture.java
@@ -1,5 +1,6 @@
 package net.teumteum.integration;
 
+import java.util.List;
 import java.util.UUID;
 import net.teumteum.core.security.Authenticated;
 import net.teumteum.user.domain.User;
@@ -8,8 +9,13 @@ import net.teumteum.user.domain.request.UserRegisterRequest.Job;
 import net.teumteum.user.domain.request.UserRegisterRequest.Terms;
 import net.teumteum.user.domain.request.UserUpdateRequest;
 import net.teumteum.user.domain.request.UserUpdateRequest.NewJob;
+import net.teumteum.user.domain.request.UserWithdrawRequest;
 
 public class RequestFixture {
+
+    public static UserWithdrawRequest userWithdrawRequest(List<String> withdrawReasons) {
+        return new UserWithdrawRequest(withdrawReasons);
+    }
 
     public static UserUpdateRequest userUpdateRequest(User user) {
         return new UserUpdateRequest(user.getId(), "new_name", user.getBirth(), user.getCharacterId(),

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -240,23 +240,26 @@ class UserIntegrationTest extends IntegrationTest {
 
             loginContext.setUserId(me.getId());
 
-            // when & then
+            var request = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
 
-            assertThatCode(() -> api.withdrawUser(VALID_TOKEN))
+            // when & then
+            assertThatCode(() -> api.withdrawUser(VALID_TOKEN, request))
                 .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("해당 회원이 존재하지 않으면, 500 에러를 반환한다.")
-        void Return_500_error_if_user_not_exist() {
+        @DisplayName("해당 회원이 존재하지 않으면, 400 에러를 반환한다.")
+        void Return_400_error_if_user_not_exist() {
             // given
             repository.clearUserRepository();
 
+            var request = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
+
             // when
-            var result = api.withdrawUser(VALID_TOKEN);
+            var result = api.withdrawUser(VALID_TOKEN, request);
 
             // then
-            Assertions.assertThat(result.expectStatus().is5xxServerError()
+            Assertions.assertThat(result.expectStatus().isBadRequest()
                     .expectBody(ErrorResponse.class)
                     .returnResult()
                     .getResponseBody())

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -68,3 +68,12 @@ create table if not exists users_friends
     friends  bigint not null,
     foreign key (users_id) references users (id)
 );
+
+create table if not exists withdraw_reason
+(
+    id              bigint       not null auto_increment,
+    withdraw_reason varchar(30)  not null,
+    created_at      timestamp(6) not null,
+    updated_at      timestamp(6) not null,
+    primary key (id)
+);


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
회원 탈퇴 시 서비스 정보 수집을 위해 사유 저장 로직을 추가합니다.

## 🕶️ 어떻게 해결했나요?
- [x] API 수정
- [x] 단위 테스트 추가 구현
- [x] 통합 테스트 수정  

## 🦀 이슈 넘버
- close #117 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
