### PR TITLE
fix: 모임 규격 변경

### DIFF
--- a/src/main/java/net/teumteum/meeting/domain/MeetingArea.java
+++ b/src/main/java/net/teumteum/meeting/domain/MeetingArea.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 @Getter
 @Builder
@@ -24,7 +25,13 @@ public class MeetingArea {
     private String addressDetail;
 
     public static MeetingArea of(String roadName, String addressDetail) {
-        return new MeetingArea(roadName.split(" ")[1], roadName, addressDetail);
+        return new MeetingArea(toMainStreet(roadName), roadName, addressDetail);
+    }
+
+    private static String toMainStreet(String roadName) {
+        String[] roadNameSplit = roadName.split(" ");
+        Assert.isTrue(roadNameSplit.length >= 2, "잘못된 도로명 주소입니다. \"" + roadName + "\"");
+        return roadNameSplit[0] + " " + roadNameSplit[1];
     }
 
 }

--- a/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
@@ -1,5 +1,8 @@
 package net.teumteum.integration;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.stream.Stream;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.meeting.domain.Meeting;
 import net.teumteum.meeting.domain.Topic;
@@ -15,10 +18,6 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.stream.Stream;
 
 @DisplayName("미팅 통합테스트의")
 class MeetingIntegrationTest extends IntegrationTest {

--- a/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
@@ -160,7 +160,7 @@ public class MeetingFixture {
         private String introduction = "모임에 대한 간단한 설명입니다.";
 
         @Builder.Default
-        private MeetingArea meetingArea = new MeetingArea("강남구", "서울특별시 강남대로 390", "강남역 11번 출구");
+        private MeetingArea meetingArea = MeetingArea.of("서울 강남구 강남대로 390", "강남역 11번 출구");
 
         @Builder.Default
         private int numberOfRecruits = 3;
@@ -169,7 +169,7 @@ public class MeetingFixture {
         private LocalDateTime promiseDateTime = LocalDateTime.of(2024, 10, 10, 0, 0);
 
         @Builder.Default
-        private Set<String> imageUrls = new HashSet<>(List.of("https://www.google.com"));
+        private Set<String> imageUrls = new HashSet<>(List.of("/1/image.jpg", "/2/image.jpg"));
     }
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
모임 거리명 저장 방식 변경

## 🕶️ 어떻게 해결했나요?
- [X] 모임에 대한 mainSteet 저장 방식을 변경했습니다.

사용자 가입 시 저장하는 활동 지역과 모임 생성 시 사용하는 도로명 주소 API의 차이로 인한 수정
기존에 `강남구` 또는 `성남시` 처럼 저장되던 주소를 `서울 강남구` 또는 `경기 성남시` 형태로 변경

## 🦀 이슈 넘버
close #126 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
