### PR TITLE
refactor: 유저조회, 자신조회, 유저들 조회 api응답에 친구 수 필드 추가

### DIFF
--- a/src/main/java/net/teumteum/user/domain/response/UserGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserGetResponse.java
@@ -17,7 +17,8 @@ public record UserGetResponse(
     String status,
     String goal,
     Job job,
-    List<String> interests
+    List<String> interests,
+    int friends
 ) {
 
     public static UserGetResponse of(User user) {
@@ -33,7 +34,8 @@ public record UserGetResponse(
             user.getStatus().name(),
             user.getGoal(),
             Job.of(user),
-            user.getInterests()
+            user.getInterests(),
+            user.getFriends().size()
         );
     }
 

--- a/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
@@ -19,7 +19,8 @@ public record UserMeGetResponse(
     String goal,
     Job job,
     String oauthType,
-    List<String> interests
+    List<String> interests,
+    int friends
 ) {
 
     public static UserMeGetResponse of(User user) {
@@ -36,7 +37,8 @@ public record UserMeGetResponse(
             user.getGoal(),
             Job.of(user),
             user.getOauth().getAuthenticated().name(),
-            user.getInterests()
+            user.getInterests(),
+            user.getFriends().size()
         );
     }
 

--- a/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserMeGetResponse.java
@@ -18,7 +18,6 @@ public record UserMeGetResponse(
     String status,
     String goal,
     Job job,
-    String oauthType,
     List<String> interests,
     int friends
 ) {
@@ -36,7 +35,6 @@ public record UserMeGetResponse(
             user.getStatus().name(),
             user.getGoal(),
             Job.of(user),
-            user.getOauth().getAuthenticated().name(),
             user.getInterests(),
             user.getFriends().size()
         );

--- a/src/main/java/net/teumteum/user/domain/response/UsersGetByIdResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UsersGetByIdResponse.java
@@ -28,7 +28,8 @@ public record UsersGetByIdResponse(
         String status,
         String goal,
         Job job,
-        List<String> interests
+        List<String> interests,
+        int friends
     ) {
 
         public static UserGetResponse of(User user) {
@@ -44,7 +45,8 @@ public record UsersGetByIdResponse(
                 user.getStatus().name(),
                 user.getGoal(),
                 Job.of(user),
-                user.getInterests()
+                user.getInterests(),
+                user.getFriends().size()
             );
         }
 


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
유저조회, 자신조회, 유저들 조회 api의 응답에 친구 수 필드를 추가 했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 유저조회 응답 필드에 friends 필드 추가
- [x] 자신조회 응답 필드에 friends 필드 추가 
- [x] 유저들 조회 응답 필드에 friends 필드 추가

## 🦀 이슈 넘버
- close #134 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
