### PR TITLE
refactor: 틈틈 위치 기반 로직 수정 및 테스트 

### DIFF
--- a/src/main/java/net/teumteum/core/config/RedisConfig.java
+++ b/src/main/java/net/teumteum/core/config/RedisConfig.java
@@ -23,12 +23,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
-        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/net/teumteum/core/security/service/RedisService.java
+++ b/src/main/java/net/teumteum/core/security/service/RedisService.java
@@ -1,30 +1,72 @@
 package net.teumteum.core.security.service;
 
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
 import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import net.teumteum.teum_teum.domain.UserLocation;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class RedisService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String HASH_KEY = "userLocation";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private ValueOperations<String, String> valueOperations;
+
+    @PostConstruct
+    void init() {
+        valueOperations = redisTemplate.opsForValue();
+    }
+
 
     public String getData(String key) {
-        return (String) redisTemplate.opsForValue().get(key);
+        return valueOperations.get(key);
     }
 
     public void setData(String key, String value) {
-        redisTemplate.opsForValue().set(key, value);
+        valueOperations.set(key, value);
     }
 
     public void setDataWithExpiration(String key, String value, Long duration) {
         Duration expireDuration = Duration.ofSeconds(duration);
-        redisTemplate.opsForValue().set(key, value, expireDuration);
+        valueOperations.set(key, value, expireDuration);
     }
 
     public void deleteData(String key) {
-        redisTemplate.delete(key);
+        valueOperations.getOperations().delete(key);
+    }
+
+    public void setUserLocation(UserLocation userLocation, Long duration) {
+        String key = HASH_KEY + userLocation.id();
+        String value;
+        try {
+            value = objectMapper.writeValueAsString(userLocation);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        valueOperations.set(key, value, duration);
+    }
+
+    public Set<UserLocation> getAllUserLocations() {
+        Set<String> keys = redisTemplate.keys(HASH_KEY + ":*");
+        return requireNonNull(keys).stream().map(key -> {
+            String value = valueOperations.get(key);
+            try {
+                return objectMapper.readValue(value, UserLocation.class);
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/net/teumteum/teum_teum/controller/TeumTeumController.java
+++ b/src/main/java/net/teumteum/teum_teum/controller/TeumTeumController.java
@@ -34,21 +34,15 @@ public class TeumTeumController {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {
-        Sentry.captureException(illegalArgumentException);
-        return ErrorResponse.of(illegalArgumentException);
-    }
-
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ErrorResponse handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException methodArgumentNotValidException) {
-        Sentry.captureException(methodArgumentNotValidException);
-
-        BindingResult bindingResult = methodArgumentNotValidException.getBindingResult();
-        List<ObjectError> errors = bindingResult.getAllErrors();
-
-        return ErrorResponse.of(errors.get(0).getDefaultMessage());
+    @ExceptionHandler({IllegalArgumentException.class, MethodArgumentNotValidException.class})
+    public ErrorResponse handleException(Exception exception) {
+        Sentry.captureException(exception);
+        if (exception instanceof MethodArgumentNotValidException methodArgumentNotValidException) {
+            BindingResult bindingResult = methodArgumentNotValidException.getBindingResult();
+            List<ObjectError> errors = bindingResult.getAllErrors();
+            return ErrorResponse.of(errors.get(0).getDefaultMessage());
+        } else {
+            return ErrorResponse.of(exception);
+        }
     }
 }

--- a/src/main/java/net/teumteum/teum_teum/controller/TeumTeumController.java
+++ b/src/main/java/net/teumteum/teum_teum/controller/TeumTeumController.java
@@ -30,7 +30,14 @@ public class TeumTeumController {
     @ResponseStatus(HttpStatus.OK)
     public UserAroundLocationsResponse getUserAroundLocations(
         @Valid @RequestBody UserLocationRequest request) {
-        return teumTeumService.processingUserAroundLocations(request);
+        return teumTeumService.saveAndGetUserAroundLocations(request);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {
+        Sentry.captureException(illegalArgumentException);
+        return ErrorResponse.of(illegalArgumentException);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/net/teumteum/teum_teum/domain/UserLocation.java
+++ b/src/main/java/net/teumteum/teum_teum/domain/UserLocation.java
@@ -1,8 +1,9 @@
 package net.teumteum.teum_teum.domain;
 
-
-public record UserData(
+`public record UserLocation(
     Long id,
+    Double latitude,
+    Double longitude,
     String name,
     String jobDetailClass,
     Long characterId

--- a/src/main/java/net/teumteum/teum_teum/domain/UserLocation.java
+++ b/src/main/java/net/teumteum/teum_teum/domain/UserLocation.java
@@ -1,6 +1,6 @@
 package net.teumteum.teum_teum.domain;
 
-`public record UserLocation(
+public record UserLocation(
     Long id,
     Double latitude,
     Double longitude,

--- a/src/main/java/net/teumteum/teum_teum/domain/request/UserLocationRequest.java
+++ b/src/main/java/net/teumteum/teum_teum/domain/request/UserLocationRequest.java
@@ -2,15 +2,15 @@ package net.teumteum.teum_teum.domain.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import net.teumteum.teum_teum.domain.UserData;
+import net.teumteum.teum_teum.domain.UserLocation;
 
 public record UserLocationRequest(
-    @NotNull(message = "경도는 필수 입력값입니다.")
-    Double longitude,
-    @NotNull(message = "위도는 필수 입력값입니다.")
-    Double latitude,
     @NotNull(message = "id 는 필수 입력값입니다.")
     Long id,
+    @NotNull(message = "위도는 필수 입력값입니다.")
+    Double latitude,
+    @NotNull(message = "경도는 필수 입력값입니다.")
+    Double longitude,
     @NotBlank(message = "이름은 필수 입력값입니다.")
     String name,
     @NotBlank(message = "직무는 필수 입력값입니다.")
@@ -19,7 +19,7 @@ public record UserLocationRequest(
     Long characterId
 ) {
 
-    public UserData toUserData() {
-        return new UserData(id, name, jobDetailClass, characterId);
+    public UserLocation toUserLocation() {
+        return new UserLocation(id, latitude, longitude, name, jobDetailClass, characterId);
     }
 }

--- a/src/main/java/net/teumteum/teum_teum/domain/response/UserAroundLocationsResponse.java
+++ b/src/main/java/net/teumteum/teum_teum/domain/response/UserAroundLocationsResponse.java
@@ -1,13 +1,13 @@
 package net.teumteum.teum_teum.domain.response;
 
 import java.util.List;
-import net.teumteum.teum_teum.domain.UserData;
+import net.teumteum.teum_teum.domain.UserLocation;
 
 public record UserAroundLocationsResponse(
-    List<UserAroundLocationResponse> userLocations
+    List<UserAroundLocationResponse> aroundUserLocations
 ) {
 
-    public static UserAroundLocationsResponse of(List<UserData> userData) {
+    public static UserAroundLocationsResponse of(List<UserLocation> userData) {
         return new UserAroundLocationsResponse(
             userData.stream()
                 .map(UserAroundLocationResponse::of)
@@ -23,13 +23,13 @@ public record UserAroundLocationsResponse(
     ) {
 
         public static UserAroundLocationResponse of(
-            UserData userData
+            UserLocation userLocation
         ) {
             return new UserAroundLocationResponse(
-                userData.id(),
-                userData.name(),
-                userData.jobDetailClass(),
-                userData.characterId()
+                userLocation.id(),
+                userLocation.name(),
+                userLocation.jobDetailClass(),
+                userLocation.characterId()
             );
         }
     }

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -28,7 +28,7 @@ public class Repository {
 
     private final RedisService redisService;
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public User saveAndGetUser() {
         var user = UserFixture.getNullIdUser();

--- a/src/test/java/net/teumteum/integration/TeumTeumIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/TeumTeumIntegrationTest.java
@@ -2,16 +2,14 @@ package net.teumteum.integration;
 
 import java.util.List;
 import net.teumteum.teum_teum.UserLocationFixture;
-import net.teumteum.teum_teum.domain.UserData;
+import net.teumteum.teum_teum.domain.UserLocation;
 import net.teumteum.teum_teum.domain.response.UserAroundLocationsResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.geo.Point;
 import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @DisplayName("틈틈 서비스 통합테스트의")
 public class TeumTeumIntegrationTest extends IntegrationTest {
@@ -22,22 +20,14 @@ public class TeumTeumIntegrationTest extends IntegrationTest {
 
         private static final String VALID_TOKEN = "VALID_TOKEN";
         private static final String INVALID_TOKEN = "IN_VALID_TOKEN";
-        private static final String KEY = "userLocation";
-        private static final long currentTimeMillis = 2000L;
 
         @BeforeEach
         void init() throws JsonProcessingException {
-            Point point01 = new Point(120.3, -22.4);
-            Point point02 = new Point(120.4, -22.2);
+            UserLocation userLocation01 = new UserLocation(100L, 20.2, 20.2, "Selly", "frontend", 1L);
+            UserLocation userLocation02 = new UserLocation(101L, 20.2, 20.2, "John", "Design", 2L);
 
-            UserData userData01 = new UserData(100L, "Selly", "frontend", 1L);
-            UserData userData02 = new UserData(101L, "Tom", "UX design", 5L);
-
-            redisRepository.saveGeoRedisData(KEY, point01,
-                new ObjectMapper().writeValueAsString(userData01 + ":" + currentTimeMillis));
-
-            redisRepository.saveGeoRedisData(KEY, point02,
-                new ObjectMapper().writeValueAsString(userData02 + ":" + currentTimeMillis));
+            redisRepository.setUserLocation(userLocation01, 60L);
+            redisRepository.setUserLocation(userLocation02, 60L);
         }
 
         @Test
@@ -55,7 +45,7 @@ public class TeumTeumIntegrationTest extends IntegrationTest {
                     result.expectBody(UserAroundLocationsResponse.class).returnResult()
                         .getResponseBody())
                 .usingRecursiveComparison()
-                .isNull();
+                .isNotNull();
         }
     }
 }

--- a/src/test/java/net/teumteum/teum_teum/UserLocationFixture.java
+++ b/src/test/java/net/teumteum/teum_teum/UserLocationFixture.java
@@ -16,9 +16,9 @@ public class UserLocationFixture {
 
     public static UserLocationRequest newUserLocationRequest(UserLocationBuilder userLocationBuilder) {
         return new UserLocationRequest(
+            userLocationBuilder.id,
             userLocationBuilder.longitude,
             userLocationBuilder.latitude,
-            userLocationBuilder.id,
             userLocationBuilder.name,
             userLocationBuilder.jobDetailClass,
             userLocationBuilder.characterId
@@ -39,10 +39,10 @@ public class UserLocationFixture {
     public static class UserLocationBuilder {
 
         @Builder.Default
-        private Double longitude = 120.5;
+        private Double longitude = 20.2;
 
         @Builder.Default
-        private Double latitude = -22.3;
+        private Double latitude = 20.2;
 
         @Builder.Default
         private Long id = 1L;


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
우리 서비스의 기능 중 `친해지기` 기능을 위한 위치 기반 로직을 수정했습니다.
**(기존 Redis Geo 는 해당 기능을 구현하기에 적합하지 않다고 판단 ! Redis Geo 로 해결할 수 있을 것 같다면 피드백 부탁드립니다. )**

![스크린샷 2024-01-22 오후 10 41 40](https://github.com/depromeet/teum-teum-server/assets/96874318/71c4f275-9a2c-48f0-a2b4-53e75c8abf57)


## 🕶️ 어떻게 해결했나요?
- [x] 기존 Redis Geo -> Redis String 방식으로 변경
   1. Redis Geo 는 유효기간 설정을 하지 못하는 이슈
   2. 기본 Redis String 을 사용해서 직렬화 후 저장(조회하는 경우 역직렬화 필요)
   3. 유효기간 설정 이유는 주변 유저 조회시 친해지기 앱을 통해 api 을 요청한지 1분이 지난 유저 데이터는 자연스럽게 거르기 위함힙니다.
- [x] 테스트 수정

## 🦀 이슈 넘버
- close #124 

## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
- 🧭 위치기반 로직 
 1. 현재 로그인한 유저는 위치기반 API 을 요청
 2. 해당 유저 위치 업데이트 이때, 유효기간을 1분으로 설정(Redis 는 유효기간이 지나면 자동 삭제)
 3. 그 후, 주변 100 m 이내 6명을 거리 순  역직렬화을 통해 오름차순으로 정렬해서 조회( 이때, 자기 id 와 동일한 데이터는 제외)
 4. 이를 통해 redis 에서 모든 데이터를 조회해서 status 을 통해 거를 필요도 없고(유효기간 때문에), 또한 간단한 계산을 통해 6개만 뽑으면 되니 간단하게 로직을 구현할 수 있다.
<!--
## 참고자료
-->
