### PR TITLE
refactor: 통합 테스트시 인증 객체 관련 로직 수정

### DIFF
--- a/src/main/java/net/teumteum/core/security/service/SecurityService.java
+++ b/src/main/java/net/teumteum/core/security/service/SecurityService.java
@@ -17,8 +17,7 @@ public class SecurityService {
     }
 
     public Long getCurrentUserId() {
-        return getUserAuthentication() == null ? userConnector.findAllUser().get(0).getId()
-            : getUserAuthentication().getId();
+        return getUserAuthentication().getId();
     }
 
 

--- a/src/test/java/net/teumteum/integration/IntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/IntegrationTest.java
@@ -21,7 +21,8 @@ import org.springframework.test.context.ContextConfiguration;
     RedisRepository.class,
     Application.class,
     GptTestServer.class,
-    TestLoginContext.class
+    TestLoginContext.class,
+    SecurityContextSetting.class
 })
 abstract public class IntegrationTest {
 
@@ -37,9 +38,17 @@ abstract public class IntegrationTest {
     @Autowired
     protected RedisRepository redisRepository;
 
+    @Autowired
+    protected SecurityContextSetting securityContextSetting;
+
     @AfterEach
     @BeforeEach
     void clearAll() {
         repository.clear();
+    }
+
+    @AfterEach
+    void setSecurityContextHolderStrategy() {
+        securityContextSetting.clearSecurityContext();
     }
 }

--- a/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
@@ -70,7 +70,8 @@ class MeetingIntegrationTest extends IntegrationTest {
         void Delete_meeting_if_exist_meeting_id_received() {
             // given
             var host = repository.saveAndGetUser();
-            loginContext.setUserId(host.getId());
+            securityContextSetting.set(host.getId());
+
 
             var meeting = repository.saveAndGetOpenMeetingWithHostId(host.getId());
             // when
@@ -84,7 +85,7 @@ class MeetingIntegrationTest extends IntegrationTest {
         void Return_400_bad_request_if_closed_meeting_id_received() {
             // given
             var host = repository.saveAndGetUser();
-            loginContext.setUserId(host.getId());
+            securityContextSetting.set(host.getId());
             var meeting = repository.saveAndGetCloseMeetingWithHostId(host.getId());
             // when
             var result = api.deleteMeeting(VALID_TOKEN, meeting.getId());
@@ -98,7 +99,7 @@ class MeetingIntegrationTest extends IntegrationTest {
         void Return_400_bad_request_if_hostId_and_userId_are_different() {
             // given
             var user = repository.saveAndGetUser();
-            loginContext.setUserId(user.getId());
+            securityContextSetting.set(user.getId());
 
             var host = repository.saveAndGetUser();
             var meeting = repository.saveAndGetOpenMeetingWithHostId(host.getId());
@@ -242,7 +243,7 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var existMeeting = repository.saveAndGetOpenMeeting();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
             // when
             var result = api.joinMeeting(VALID_TOKEN, existMeeting.getId());
             // then
@@ -263,6 +264,8 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetOpenMeeting();
 
+            securityContextSetting.set(me.getId());
+
             loginContext.setUserId(me.getId());
             api.joinMeeting(VALID_TOKEN, meeting.getId());
             // when
@@ -279,7 +282,7 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetCloseMeeting();
 
-            loginContext.setUserId(0L);
+            securityContextSetting.set(me.getId());
             // when
             var result = api.joinMeeting(VALID_TOKEN, meeting.getId());
             // then
@@ -293,6 +296,8 @@ class MeetingIntegrationTest extends IntegrationTest {
             // given
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetOpenFullMeeting();
+            securityContextSetting.set(me.getId());
+
             // when
             var result = api.joinMeeting(VALID_TOKEN, meeting.getId());
             // then
@@ -312,7 +317,7 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetOpenMeeting();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
             api.joinMeeting(VALID_TOKEN, meeting.getId());
             // when
             var result = api.cancelMeeting(VALID_TOKEN, meeting.getId());
@@ -327,7 +332,7 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetOpenMeeting();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
             // when
             var result = api.cancelMeeting(VALID_TOKEN, meeting.getId());
             // then
@@ -347,7 +352,7 @@ class MeetingIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             var meeting = repository.saveAndGetCloseMeeting();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
             // when
             var result = api.cancelMeeting(VALID_TOKEN, meeting.getId());
             // then

--- a/src/test/java/net/teumteum/integration/SecurityContextSetting.java
+++ b/src/test/java/net/teumteum/integration/SecurityContextSetting.java
@@ -1,5 +1,8 @@
 package net.teumteum.integration;
 
+import static org.springframework.security.core.context.SecurityContextHolder.MODE_GLOBAL;
+import static org.springframework.security.core.context.SecurityContextHolder.MODE_THREADLOCAL;
+
 import net.teumteum.core.security.UserAuthentication;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserFixture;
@@ -9,10 +12,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 @TestComponent
 public class SecurityContextSetting {
-    public void set() {
-        User user = UserFixture.getIdUser();
+    public void set(Long id) {
+        SecurityContextHolder.setStrategyName(MODE_GLOBAL);
+        User user = UserFixture.getUserWithId(id);
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(new UserAuthentication(user));
         SecurityContextHolder.setContext(context);
+    }
+
+    public void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+        SecurityContextHolder.setStrategyName(MODE_THREADLOCAL);
     }
 }

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -34,6 +34,8 @@ class UserIntegrationTest extends IntegrationTest {
             var user = repository.saveAndGetUser();
             var expected = UserGetResponse.of(user);
 
+            securityContextSetting.set(user.getId());
+
             // when
             var result = api.getUser(VALID_TOKEN, user.getId());
 
@@ -119,8 +121,7 @@ class UserIntegrationTest extends IntegrationTest {
         void Return_my_info_if_valid_token_received() {
             // given
             var me = repository.saveAndGetUser();
-            loginContext.setUserId(me.getId());
-
+            securityContextSetting.set(me.getId());
             var expected = UserMeGetResponse.of(me);
 
             // when
@@ -145,6 +146,8 @@ class UserIntegrationTest extends IntegrationTest {
         void Update_user_info() {
             // given
             var existUser = repository.saveAndGetUser();
+            securityContextSetting.set(existUser.getId());
+
             List<User> allUser = repository.getAllUser();
             var updateUser = RequestFixture.userUpdateRequest(existUser);
 
@@ -168,6 +171,8 @@ class UserIntegrationTest extends IntegrationTest {
             var myToken = "JWT MY_TOKEN";
             var friend = repository.saveAndGetUser();
 
+            securityContextSetting.set(me.getId());
+
             // when
             var result = api.addFriends(myToken, friend.getId());
 
@@ -188,7 +193,8 @@ class UserIntegrationTest extends IntegrationTest {
             var friend1 = repository.saveAndGetUser();
             var friend2 = repository.saveAndGetUser();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
+
             api.addFriends(VALID_TOKEN, friend1.getId());
             api.addFriends(VALID_TOKEN, friend2.getId());
 
@@ -211,7 +217,7 @@ class UserIntegrationTest extends IntegrationTest {
             // given
             var me = repository.saveAndGetUser();
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
 
             var expected = FriendsResponse.of(List.of());
 
@@ -238,7 +244,7 @@ class UserIntegrationTest extends IntegrationTest {
             var me = repository.saveAndGetUser();
             redisRepository.saveRedisDataWithExpiration(String.valueOf(me.getId()), VALID_TOKEN, DURATION);
 
-            loginContext.setUserId(me.getId());
+            securityContextSetting.set(me.getId());
 
             var request = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
 


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
통합 테스트인 경우 `Thread Local` 로 동작해서 오류가 났던 인증 객체 적용 부분을 수정합니다.

## 🕶️ 어떻게 해결했나요?
- [x] SecurityContextSetting 클래스 , 메소드 구현
- [x] 통합 테스트 적용
- [x] 테스트  

## 🦀 이슈 넘버
- close #148 

## 어떤 부분에 집중하여 리뷰해야 할까요?
`문제` :   기존 WebTestClient 로 통합 테스트를 진행하면 실제 테스트 대상 로직 (Controller) 에 진입하는 순간 SecurityContext 에 저장했던 인증 객체가 null 로 변하는 이슈가 있었습니다.
`원인` : SecurityContextHolder 가 Thread Local 로 동작하기 때문에 동일한 Test Context 에서도 유지되지 않았던 것 
`해결` : SecurityContextHolder 을 Global(전역) 으로 동작하도록 변경하였습니다.
## 참고자료

- [Spring SecuritySecurityContextHolder 에 대해](https://hyunwook.dev/121)

