### PR TITLE
feat: 리뷰 등록시 회원 매너 온도 반영 기능 추가 및 리뷰 등록 리팩토링

### DIFF
--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -113,7 +113,7 @@ public class UserController {
         @RequestParam Long meetingId,
         @Valid @RequestBody ReviewRegisterRequest request
     ) {
-        userService.registerReview(meetingId, request);
+        userService.registerReview(meetingId, getCurrentUserId(), request);
     }
 
     @GetMapping("/reviews")

--- a/src/main/java/net/teumteum/user/domain/Review.java
+++ b/src/main/java/net/teumteum/user/domain/Review.java
@@ -1,7 +1,14 @@
 package net.teumteum.user.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Review {
-    별로에요,
-    좋아요,
-    최고에요
+    별로에요(-1),
+    좋아요(1),
+    최고에요(2);
+
+    private final int score;
 }

--- a/src/main/java/net/teumteum/user/domain/User.java
+++ b/src/main/java/net/teumteum/user/domain/User.java
@@ -122,9 +122,13 @@ public class User extends TimeBaseEntity {
         friends.add(user.id);
     }
 
-    public void addReview(Review review) {
+    public void registerReview(Review review) {
         List<Review> newReviews = new ArrayList<>(reviews);
         newReviews.add(review);
         reviews = newReviews;
+    }
+
+    public void updateMannerTemperature(Review review) {
+        mannerTemperature += review.getScore();
     }
 }

--- a/src/main/java/net/teumteum/user/domain/User.java
+++ b/src/main/java/net/teumteum/user/domain/User.java
@@ -123,9 +123,7 @@ public class User extends TimeBaseEntity {
     }
 
     public void registerReview(Review review) {
-        List<Review> newReviews = new ArrayList<>(reviews);
-        newReviews.add(review);
-        reviews = newReviews;
+        reviews.add(review);
     }
 
     public void updateMannerTemperature(Review review) {

--- a/src/main/java/net/teumteum/user/domain/request/ReviewRegisterRequest.java
+++ b/src/main/java/net/teumteum/user/domain/request/ReviewRegisterRequest.java
@@ -8,7 +8,7 @@ import net.teumteum.user.domain.Review;
 
 public record ReviewRegisterRequest(
     @Valid
-    @Size(min = 3, max = 6)
+    @Size(min = 2, max = 5)
     List<UserReviewRegisterRequest> reviews
 ) {
 

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -103,8 +103,9 @@ public class UserService {
 
 
     @Transactional
-    public void registerReview(Long meetingId, ReviewRegisterRequest request) {
+    public void registerReview(Long meetingId, Long currentUserId, ReviewRegisterRequest request) {
         checkMeetingExistence(meetingId);
+        checkCurrentUserIdInRequest(request, currentUserId);
 
         request.reviews()
             .forEach(userReview -> {
@@ -150,6 +151,12 @@ public class UserService {
     private void checkMeetingExistence(Long meetingId) {
         if (!meetingConnector.existById(meetingId)) {
             throw new IllegalArgumentException("meetingId에 해당하는 meeting을 찾을 수 없습니다. \"" + meetingId + "\"");
+        }
+    }
+
+    private void checkCurrentUserIdInRequest(ReviewRegisterRequest request, Long currentUserId) {
+        if (request.reviews().stream().anyMatch(review -> review.id().equals(currentUserId))) {
+            throw new IllegalArgumentException("나의 리뷰에 대한 리뷰를 작성할 수 없습니다.");
         }
     }
 }

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -105,12 +105,13 @@ public class UserService {
     @Transactional
     public void registerReview(Long meetingId, Long currentUserId, ReviewRegisterRequest request) {
         checkMeetingExistence(meetingId);
-        checkCurrentUserIdInRequest(request, currentUserId);
+        checkUserNotRegisterSelfReview(request, currentUserId);
 
         request.reviews()
             .forEach(userReview -> {
                 User user = getUser(userReview.id());
-                user.addReview(userReview.review());
+                user.registerReview(userReview.review());
+                user.updateMannerTemperature(userReview.review());
             });
     }
 
@@ -149,14 +150,18 @@ public class UserService {
     }
 
     private void checkMeetingExistence(Long meetingId) {
-        if (!meetingConnector.existById(meetingId)) {
-            throw new IllegalArgumentException("meetingId에 해당하는 meeting을 찾을 수 없습니다. \"" + meetingId + "\"");
-        }
+        Assert.isTrue(meetingConnector.existById(meetingId),
+            () -> {
+                throw new IllegalArgumentException("meetingId에 해당하는 meeting을 찾을 수 없습니다. \"" + meetingId + "\"");
+            }
+        );
     }
 
-    private void checkCurrentUserIdInRequest(ReviewRegisterRequest request, Long currentUserId) {
-        if (request.reviews().stream().anyMatch(review -> review.id().equals(currentUserId))) {
-            throw new IllegalArgumentException("나의 리뷰에 대한 리뷰를 작성할 수 없습니다.");
-        }
+    private void checkUserNotRegisterSelfReview(ReviewRegisterRequest request, Long currentUserId) {
+        Assert.isTrue(request.reviews().stream().noneMatch(review -> review.id().equals(currentUserId)),
+            () -> {
+                throw new IllegalArgumentException("나의 리뷰에 대한 리뷰를 작성할 수 없습니다.");
+            }
+        );
     }
 }

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -4,6 +4,7 @@ import java.util.List;
 import net.teumteum.meeting.config.PageableHandlerMethodArgumentResolver;
 import net.teumteum.meeting.domain.Topic;
 import net.teumteum.teum_teum.domain.request.UserLocationRequest;
+import net.teumteum.user.domain.request.ReviewRegisterRequest;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserUpdateRequest;
 import net.teumteum.user.domain.request.UserWithdrawRequest;
@@ -186,6 +187,16 @@ class Api {
             .get()
             .uri("/users/reviews")
             .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .exchange();
+    }
+
+    ResponseSpec registerUserReview(String accessToken, Long meetingId, ReviewRegisterRequest request) {
+        String uri = "/users/reviews?meetingId=" + meetingId;
+        return webTestClient
+            .post()
+            .uri(uri)
+            .header(HttpHeaders.AUTHORIZATION, accessToken)
+            .bodyValue(request)
             .exchange();
     }
 }

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -2,6 +2,7 @@ package net.teumteum.integration;
 
 
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.config.AppConfig;
@@ -38,6 +39,13 @@ public class Repository {
     public User saveAndGetUser(Long id) {
         var user = UserFixture.getUserWithId(id);
         return userRepository.saveAndFlush(user);
+    }
+
+    public List<User> saveAndGetUsers(int size) {
+        return Stream.generate(UserFixture::getNullIdUser)
+            .limit(size)
+            .map(userRepository::saveAndFlush)
+            .toList();
     }
 
     List<User> getAllUser() {

--- a/src/test/java/net/teumteum/integration/RequestFixture.java
+++ b/src/test/java/net/teumteum/integration/RequestFixture.java
@@ -5,8 +5,10 @@ import static net.teumteum.user.domain.Review.좋아요;
 import static net.teumteum.user.domain.Review.최고에요;
 
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import net.teumteum.core.security.Authenticated;
+import net.teumteum.user.domain.Review;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.request.ReviewRegisterRequest;
 import net.teumteum.user.domain.request.ReviewRegisterRequest.UserReviewRegisterRequest;
@@ -62,9 +64,22 @@ public class RequestFixture {
         return new ReviewRegisterRequest(userReviewRegisterRequests());
     }
 
+    public static ReviewRegisterRequest reviewRegisterRequest(List<User> users) {
+        return new ReviewRegisterRequest(userReviewRegisterRequests(users));
+    }
+
     private static List<UserReviewRegisterRequest> userReviewRegisterRequests() {
         return List.of(new UserReviewRegisterRequest(1L, 별로에요), new UserReviewRegisterRequest(2L, 최고에요),
             new UserReviewRegisterRequest(3L, 좋아요));
+    }
+
+    private static List<UserReviewRegisterRequest> userReviewRegisterRequests(List<User> users) {
+        Review[] reviews = Review.values();
+        int length = reviews.length;
+
+        return users.stream()
+            .map(user -> new UserReviewRegisterRequest(user.getId(), reviews[new Random().nextInt(length)]))
+            .toList();
     }
 
     private static Job job(User user) {

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
 import net.teumteum.core.error.ErrorResponse;
+import net.teumteum.meeting.domain.Meeting;
 import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserFixture;
+import net.teumteum.user.domain.request.ReviewRegisterRequest;
 import net.teumteum.user.domain.response.FriendsResponse;
 import net.teumteum.user.domain.response.UserGetResponse;
 import net.teumteum.user.domain.response.UserMeGetResponse;
@@ -13,6 +15,7 @@ import net.teumteum.user.domain.response.UserRegisterResponse;
 import net.teumteum.user.domain.response.UserReviewsResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -351,11 +354,11 @@ class UserIntegrationTest extends IntegrationTest {
 
     @Nested
     @DisplayName("회원 리뷰 조회 API는")
-    class Get_user_review_api {
+    class Get_user_reviews_api {
 
         @Test
         @DisplayName("userId 유저의 리뷰 정보를 가져온다.")
-        void Get_user_review() {
+        void Get_user_reviews() {
             // given
             var existUser = repository.saveAndGetUser();
 
@@ -371,6 +374,55 @@ class UserIntegrationTest extends IntegrationTest {
                     .getResponseBody())
                 .usingRecursiveComparison()
                 .isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 리뷰 등록 API는")
+    class Register_user_review_api {
+
+        User existUser;
+
+        List<User> users;
+
+        ReviewRegisterRequest request;
+
+        Meeting meeting;
+
+        @BeforeEach
+        void setUp() {
+            existUser = repository.saveAndGetUser();
+            users = repository.saveAndGetUsers(3);
+            request = RequestFixture.reviewRegisterRequest(users);
+            meeting = repository.saveAndGetOpenMeetings(1).get(0);
+        }
+
+        @Test
+        @DisplayName("회원 리뷰 등록 요청이 들어오면 리뷰를 등록하고, 200 OK 을 반환한다.")
+        void Return_200_OK_with_success_register_user_review() {
+            // given
+            securityContextSetting.set(existUser.getId());
+
+            // when
+            var expected = api.registerUserReview(VALID_TOKEN, meeting.getId(), request);
+
+            // then
+            Assertions.assertThat(expected.expectStatus().isOk());
+        }
+
+        @Test
+        @DisplayName("현재 로그인한 회원의 id 가 리뷰 등록 요청에 포함된다면, 회원 리뷰 등록을 실패하고 400 bad request 을 반환한다.")
+        void Return_400_bad_request_if_current_user_id_in_request() {
+            // given
+            securityContextSetting.set(users.get(0).getId());
+
+            // when
+            var expected = api.registerUserReview(VALID_TOKEN, meeting.getId(), request);
+
+            // then
+            Assertions.assertThat(expected.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult().getResponseBody());
         }
     }
 }

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -256,25 +256,6 @@ class UserIntegrationTest extends IntegrationTest {
             assertThatCode(() -> api.withdrawUser(VALID_TOKEN, request))
                 .doesNotThrowAnyException();
         }
-
-        @Test
-        @DisplayName("해당 회원이 존재하지 않으면, 500 에러를 반환한다.")
-        void Return_500_error_if_user_not_exist() {
-            // given
-            repository.clearUserRepository();
-
-            var request = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
-
-            // when
-            var result = api.withdrawUser(VALID_TOKEN, request);
-
-            // then
-            Assertions.assertThat(result.expectStatus().is5xxServerError()
-                    .expectBody(ErrorResponse.class)
-                    .returnResult()
-                    .getResponseBody())
-                .usingRecursiveComparison().isNull();
-        }
     }
 
     @Nested
@@ -344,6 +325,9 @@ class UserIntegrationTest extends IntegrationTest {
         void Logout_user() {
             // given
             var existUser = repository.saveAndGetUser();
+
+            securityContextSetting.set(existUser.getId());
+
             redisRepository.saveRedisDataWithExpiration(String.valueOf(existUser.getId()), VALID_TOKEN, DURATION);
 
             // when & then

--- a/src/test/java/net/teumteum/user/domain/UserFixture.java
+++ b/src/test/java/net/teumteum/user/domain/UserFixture.java
@@ -5,6 +5,8 @@ import static net.teumteum.user.domain.Review.별로에요;
 import static net.teumteum.user.domain.Review.좋아요;
 import static net.teumteum.user.domain.Review.최고에요;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -89,7 +91,7 @@ public class UserFixture {
         @Builder.Default
         private Terms terms = new Terms(true, true);
         @Builder.Default
-        private List<Review> reviews = List.of(최고에요, 최고에요, 최고에요, 별로에요, 좋아요, 좋아요);
+        private List<Review> reviews = new ArrayList<>(Arrays.asList(최고에요, 최고에요, 최고에요, 별로에요, 좋아요, 좋아요));
     }
 
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 회원의 신뢰도를 의미하는 매너 온도 반영 기능을 추가하며 리뷰 등록 기능을 리팩토링합니다.

## 🕶️ 어떻게 해결했나요?
- [x] 회원 매너 온도 반영 기능 추가
- [x] 기존 리뷰 등록 기능 리팩토링
- [x] 관련 테스트 코드 작성 및 수정

## 🦀 이슈 넘버

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->
- close #157 
<!--
## 참고자료
-->
