### PR TITLE
refactor: 회원 탈퇴 URI 변경

### DIFF
--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -89,7 +89,7 @@ public class UserController {
         return userService.getInterestQuestionByUserIds(userIds, balance);
     }
 
-    @PostMapping("/withdraw")
+    @PostMapping("/withdraws")
     @ResponseStatus(HttpStatus.OK)
     public void withdraw(@Valid @RequestBody UserWithdrawRequest request) {
         userService.withdraw(request, getCurrentUserId());

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -142,7 +142,7 @@ class Api {
     ResponseSpec withdrawUser(String accessToken, UserWithdrawRequest request) {
         return webTestClient
             .post()
-            .uri("/users/withdraw")
+            .uri("/users/withdraws")
             .header(HttpHeaders.AUTHORIZATION, accessToken)
             .bodyValue(request)
             .exchange();

--- a/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
@@ -268,7 +268,7 @@ class MeetingRepositoryTest {
             // then
             Assertions.assertThat(result)
                 .usingRecursiveComparison()
-                .ignoringFields("value.createdAt", "value.updatedAt", "value.id", "value.promiseTime")
+                .ignoringFields("value.createdAt", "value.updatedAt", "value.id", "value.promiseDateTime")
                 .isEqualTo(expected);
         }
     }

--- a/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
@@ -267,7 +267,8 @@ class MeetingRepositoryTest {
 
             // then
             Assertions.assertThat(result)
-                .usingElementComparatorOnFields("topic", "introduction")
+                .usingRecursiveComparison()
+                .ignoringFields("value.createdAt", "value.updatedAt", "value.id", "value.promiseTime")
                 .isEqualTo(expected);
         }
     }

--- a/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingRepositoryTest.java
@@ -267,7 +267,7 @@ class MeetingRepositoryTest {
 
             // then
             Assertions.assertThat(result)
-                .usingRecursiveComparison()
+                .usingElementComparatorOnFields("topic", "introduction")
                 .isEqualTo(expected);
         }
     }

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -135,7 +135,7 @@ public class UserControllerTest {
                 = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
 
             // when & then
-            mockMvc.perform(post("/users/withdraw")
+            mockMvc.perform(post("/users/withdraws")
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(APPLICATION_JSON)
                     .with(csrf())


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 기존 회원 탈퇴 URI 을 변경합니다.

## 🕶️ 어떻게 해결했나요?
- [x] 회원 탈퇴 URI 수정
- [x] 테스트 코드 수정

## 🦀 이슈 넘버
- close #161 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
