### PR TITLE
feat: fcm token 업데이트 api 추가

### DIFF
--- a/src/main/java/net/teumteum/alert/controller/AlertController.java
+++ b/src/main/java/net/teumteum/alert/controller/AlertController.java
@@ -1,11 +1,16 @@
 package net.teumteum.alert.controller;
 
+import io.sentry.Sentry;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.alert.domain.AlertService;
 import net.teumteum.alert.domain.request.RegisterAlertRequest;
+import net.teumteum.alert.domain.request.UpdateAlertTokenRequest;
+import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.core.security.service.SecurityService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -23,5 +28,19 @@ public class AlertController {
     public void registerAlert(@Valid @RequestBody RegisterAlertRequest registerAlertRequest) {
         var loginUserId = securityService.getCurrentUserId();
         alertService.registerAlert(loginUserId, registerAlertRequest);
+    }
+
+    @PatchMapping("/alerts")
+    @ResponseStatus(HttpStatus.OK)
+    public void updateAlert(@Valid @RequestBody UpdateAlertTokenRequest updateAlertTokenRequest) {
+        var loginUserId = securityService.getCurrentUserId();
+        alertService.updateAlertToken(loginUserId, updateAlertTokenRequest);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {
+        Sentry.captureException(illegalArgumentException);
+        return ErrorResponse.of(illegalArgumentException);
     }
 }

--- a/src/main/java/net/teumteum/alert/domain/AlertRepository.java
+++ b/src/main/java/net/teumteum/alert/domain/AlertRepository.java
@@ -1,7 +1,10 @@
 package net.teumteum.alert.domain;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,4 +12,11 @@ public interface AlertRepository extends JpaRepository<UserAlert, Long> {
 
     @Query("select u from user_alert as u where u.userId in :userIds")
     List<UserAlert> findAllByUserId(@Param("userIds") Iterable<Long> userIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from user_alert as u where u.userId = :userId")
+    Optional<UserAlert> findByUserIdWithLock(@Param("userId") Long userId);
+
+    Optional<UserAlert> findByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/net/teumteum/alert/domain/AlertService.java
+++ b/src/main/java/net/teumteum/alert/domain/AlertService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.alert.domain.request.RegisterAlertRequest;
+import net.teumteum.alert.domain.request.UpdateAlertTokenRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,8 +17,21 @@ public class AlertService {
 
     @Transactional
     public void registerAlert(Long userId, RegisterAlertRequest registerAlertRequest) {
-        var alert = new UserAlert(null, userId, registerAlertRequest.token());
-        alertRepository.save(alert);
+        alertRepository.findByUserId(userId)
+            .ifPresentOrElse(userAlert -> {
+                throw new IllegalArgumentException("이미 토큰이 생성된 user입니다. \"" + userId +"\"");
+            }, () -> {
+                var alert = new UserAlert(null, userId, registerAlertRequest.token());
+                alertRepository.save(alert);
+            });
+    }
+
+    @Transactional
+    public void updateAlertToken(Long userId, UpdateAlertTokenRequest updateAlertTokenRequest) {
+        var userAlert = alertRepository.findByUserIdWithLock(userId)
+            .orElseThrow(() -> new IllegalArgumentException("userId에 해당하는 토큰을 찾을 수 없습니다."));
+
+        userAlert.updateToken(updateAlertTokenRequest.token());
     }
 
     public List<UserAlert> findAllByUserId(Set<Long> userIds) {

--- a/src/main/java/net/teumteum/alert/domain/UserAlert.java
+++ b/src/main/java/net/teumteum/alert/domain/UserAlert.java
@@ -31,4 +31,8 @@ public class UserAlert {
     public String getToken() {
         return token;
     }
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
 }

--- a/src/main/java/net/teumteum/alert/domain/request/UpdateAlertTokenRequest.java
+++ b/src/main/java/net/teumteum/alert/domain/request/UpdateAlertTokenRequest.java
@@ -1,0 +1,10 @@
+package net.teumteum.alert.domain.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateAlertTokenRequest(
+    @NotNull
+    String token
+) {
+
+}

--- a/src/main/resources/db/migration/V10__create_alert.sql
+++ b/src/main/resources/db/migration/V10__create_alert.sql
@@ -1,5 +1,5 @@
 create table if not exists user_alert(
-  id bigint primary key,
+  id bigint primary key auto_increment,
   user_id bigint unique not null,
   token text not null
 );

--- a/src/test/java/net/teumteum/alert/domain/AlertRepositoryTest.java
+++ b/src/test/java/net/teumteum/alert/domain/AlertRepositoryTest.java
@@ -1,0 +1,46 @@
+package net.teumteum.alert.domain;
+
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@DisplayName("AlertRepository 클래스의")
+class AlertRepositoryTest {
+
+    @Autowired
+    private AlertRepository alertRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Nested
+    @DisplayName("findByUserIdWithLock 메소드는")
+    class findByUserIdWithLock_method {
+
+        @Test
+        @DisplayName("userId로 userAlert를 조회한다.")
+        void find_userAlert_by_userId() {
+            // given
+            var userId = 1L;
+            var userAlert = new UserAlert(1L, userId, "token");
+
+            alertRepository.saveAndFlush(userAlert);
+            entityManager.clear();
+
+            // when
+            var result = alertRepository.findByUserIdWithLock(userId);
+
+            // then
+            Assertions.assertThat(result).isPresent();
+        }
+    }
+
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -79,7 +79,7 @@ create table if not exists withdraw_reasons
 );
 
 create table if not exists user_alert(
-  id bigint primary key,
+  id bigint primary key auto_increment,
   user_id bigint unique not null,
   token text not null
 );


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
fcm token 업데이트 api 추가

## 🕶️ 어떻게 해결했나요?
- [x] fcm 토큰 업데이트기능을 추가했습니다. - 비관적락으로 토큰을 수정하는 도중에 알림 발송을 하지 못하도록 막았습니다.
- [x] pk에 auto_increment가 걸려있지 않는 버그를 수정했습니다.

## 🦀 이슈 넘버
- close #165 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
