### PR TITLE
feat: 회원탈퇴, 로그아웃 시, 회원 위치 데이터 삭제 로직 추가 및 위치 데이터 유효기간 변경

### DIFF
--- a/src/main/java/net/teumteum/core/security/service/RedisService.java
+++ b/src/main/java/net/teumteum/core/security/service/RedisService.java
@@ -55,7 +55,7 @@ public class RedisService {
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException(e);
         }
-        setDataWithExpiration(key,value,duration);
+        setDataWithExpiration(key, value, duration);
     }
 
     public Set<UserLocation> getAllUserLocations() {
@@ -68,5 +68,9 @@ public class RedisService {
                 throw new IllegalArgumentException(e);
             }
         }).collect(Collectors.toSet());
+    }
+
+    public void deleteUserLocation(Long id) {
+        deleteData(HASH_KEY + id);
     }
 }

--- a/src/main/java/net/teumteum/teum_teum/domain/response/UserAroundLocationsResponse.java
+++ b/src/main/java/net/teumteum/teum_teum/domain/response/UserAroundLocationsResponse.java
@@ -1,13 +1,14 @@
 package net.teumteum.teum_teum.domain.response;
 
 import java.util.List;
+import java.util.Set;
 import net.teumteum.teum_teum.domain.UserLocation;
 
 public record UserAroundLocationsResponse(
     List<UserAroundLocationResponse> aroundUserLocations
 ) {
 
-    public static UserAroundLocationsResponse of(List<UserLocation> userData) {
+    public static UserAroundLocationsResponse of(Set<UserLocation> userData) {
         return new UserAroundLocationsResponse(
             userData.stream()
                 .map(UserAroundLocationResponse::of)

--- a/src/main/java/net/teumteum/teum_teum/service/TeumTeumService.java
+++ b/src/main/java/net/teumteum/teum_teum/service/TeumTeumService.java
@@ -9,20 +9,20 @@ import static java.util.Comparator.comparingDouble;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.teumteum.core.security.service.RedisService;
 import net.teumteum.teum_teum.domain.UserLocation;
 import net.teumteum.teum_teum.domain.request.UserLocationRequest;
 import net.teumteum.teum_teum.domain.response.UserAroundLocationsResponse;
 import org.springframework.stereotype.Service;
 
-@Slf4j
+
 @Service
 @RequiredArgsConstructor
 public class TeumTeumService {
 
     private static final int SEARCH_LIMIT = 6;
-    private static final long USER_LOCATION_DATA_DURATION = 30L;
+    private static final long USER_LOCATION_DATA_DURATION = 10L;
+    private static final int AROUND_USER_LOCATION_DISTANCE = 100;
 
     private final RedisService redisService;
 
@@ -37,7 +37,7 @@ public class TeumTeumService {
         Set<UserLocation> aroundUserLocations = allUserLocations.stream()
             .filter(userLocation -> !userLocation.id().equals(request.id()))
             .filter(userLocation -> calculateDistance(request.latitude(), request.longitude(),
-                userLocation.latitude(), userLocation.longitude()) <= 100)
+                userLocation.latitude(), userLocation.longitude()) <= AROUND_USER_LOCATION_DISTANCE)
             .sorted(comparingDouble(userLocation
                 -> calculateDistance(request.latitude(), request.longitude(),
                 userLocation.latitude(), userLocation.longitude()))

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -81,8 +81,10 @@ public class UserService {
     public void withdraw(UserWithdrawRequest request, Long userId) {
         var existUser = getUser(userId);
 
-        userRepository.delete(existUser);
         redisService.deleteData(String.valueOf(userId));
+        redisService.deleteUserLocation(userId);
+
+        userRepository.delete(existUser);
 
         withdrawReasonRepository.saveAll(request.toEntity());
     }
@@ -98,6 +100,8 @@ public class UserService {
     @Transactional
     public void logout(Long userId) {
         redisService.deleteData(String.valueOf(userId));
+        redisService.deleteUserLocation(userId);
+
         SecurityService.clearSecurityContext();
     }
 

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -96,7 +96,6 @@ public class UserService {
         return UserRegisterResponse.of(savedUser.getId(), jwtService.createServiceToken(savedUser));
     }
 
-    @Transactional
     public void logout(Long userId) {
         redisService.deleteData(String.valueOf(userId));
 

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -82,7 +82,6 @@ public class UserService {
         var existUser = getUser(userId);
 
         redisService.deleteData(String.valueOf(userId));
-        redisService.deleteUserLocation(userId);
 
         userRepository.delete(existUser);
 
@@ -100,7 +99,6 @@ public class UserService {
     @Transactional
     public void logout(Long userId) {
         redisService.deleteData(String.valueOf(userId));
-        redisService.deleteUserLocation(userId);
 
         SecurityService.clearSecurityContext();
     }

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -218,6 +219,27 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].count", is(2)))
                 .andExpect(jsonPath("$[0].review").value("별로에요"));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 로그아웃 API는")
+    class Logout_user_api_unit {
+
+        @Test
+        @DisplayName("")
+        void Logout_user_with_200_ok() throws Exception {
+            // given
+            var userId = 1L;
+
+            doNothing().when(userService).logout(anyLong());
+
+            // when && then
+            mockMvc.perform(post("/users/logouts")
+                    .with(csrf())
+                    .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isOk());
         }
     }
 }

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -62,6 +62,7 @@ public class UserServiceTest {
     @Mock
     MeetingConnector meetingConnector;
 
+
     private User user;
 
     @BeforeEach
@@ -111,7 +112,28 @@ public class UserServiceTest {
     }
 
     @Nested
-    @DisplayName("유저 탈퇴 API는")
+    @DisplayName("회원 로그아웃 API는")
+    class Logout_user_api_unit {
+
+        @Test
+        @DisplayName("")
+        void If_valid_user_logout_request_return_200_OK() {
+            // given
+            Long userId = 1L;
+            doNothing().when(redisService).deleteData(anyString());
+            doNothing().when(redisService).deleteUserLocation(anyLong());
+
+            // when
+            userService.logout(userId);
+
+            // then
+            verify(redisService, times(1)).deleteData(anyString());
+            verify(redisService, times(1)).deleteUserLocation(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 API는")
     class Withdraw_user_api_unit {
 
         @Test
@@ -127,11 +149,13 @@ public class UserServiceTest {
             doNothing().when(userRepository).delete(any());
 
             doNothing().when(redisService).deleteData(anyString());
+            doNothing().when(redisService).deleteUserLocation(anyLong());
             // when
             userService.withdraw(request, user.getId());
             // then
             verify(userRepository, times(1)).findById(anyLong());
             verify(redisService, times(1)).deleteData(anyString());
+            verify(redisService, times(1)).deleteUserLocation(anyLong());
             verify(withdrawReasonRepository, times(1)).saveAll(any());
         }
     }

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -116,19 +116,17 @@ public class UserServiceTest {
     class Logout_user_api_unit {
 
         @Test
-        @DisplayName("")
+        @DisplayName("정상적인 요청시, 회원 로그아웃을 진행하고 200 OK을 반환한다.")
         void If_valid_user_logout_request_return_200_OK() {
             // given
             Long userId = 1L;
             doNothing().when(redisService).deleteData(anyString());
-            doNothing().when(redisService).deleteUserLocation(anyLong());
 
             // when
             userService.logout(userId);
 
             // then
             verify(redisService, times(1)).deleteData(anyString());
-            verify(redisService, times(1)).deleteUserLocation(anyLong());
         }
     }
 
@@ -149,13 +147,11 @@ public class UserServiceTest {
             doNothing().when(userRepository).delete(any());
 
             doNothing().when(redisService).deleteData(anyString());
-            doNothing().when(redisService).deleteUserLocation(anyLong());
             // when
             userService.withdraw(request, user.getId());
             // then
             verify(userRepository, times(1)).findById(anyLong());
             verify(redisService, times(1)).deleteData(anyString());
-            verify(redisService, times(1)).deleteUserLocation(anyLong());
             verify(withdrawReasonRepository, times(1)).saveAll(any());
         }
     }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 기존 회원 탈퇴 및 로그아웃 시 위치 데이터가 남아있는 이슈가 있었고, 삭제 로직을 추가합니다.

## 🕶️ 어떻게 해결했나요?
- [x] 회원탈퇴, 로그아웃 시 해당 id 해당하는 회원 위치 데이터 삭제 로직 추가
- [x] 회원 데이터 유효기간 `1분` -> `30초` 로 변경
- [x] 테스트 코드 수정 및 테스트 

## 🦀 이슈 넘버
- close #178 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
