### PR TITLE
test: 인증 단위 테스트 구현

### DIFF
--- a/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/net/teumteum/core/security/filter/JwtAuthenticationFilter.java
@@ -15,7 +15,6 @@ import net.teumteum.user.domain.User;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -31,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProperty jwtProperty;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
+    public void doFilterInternal(HttpServletRequest request,
         HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
         if (request.getMethod().equals("OPTIONS")) {
@@ -73,10 +72,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String resolveTokenFromRequest(HttpServletRequest request) {
         String token = request.getHeader(jwtProperty.getAccess().getHeader());
-        if (!ObjectUtils.isEmpty(token) && token.toLowerCase().startsWith(jwtProperty.getBearer().toLowerCase())) {
+        if (token.toLowerCase().startsWith(jwtProperty.getBearer().toLowerCase())) {
             return token.substring(7);
         }
-        setRequestAttribute(request, "요청에 대한 JWT 파싱 과정에서 문제가 발생했습니다.");
         return null;
     }
 

--- a/src/test/java/net/teumteum/unit/auth/controller/AuthControllerTest.java
+++ b/src/test/java/net/teumteum/unit/auth/controller/AuthControllerTest.java
@@ -1,10 +1,10 @@
 package net.teumteum.unit.auth.controller;
 
 
-import static net.teumteum.unit.auth.common.SecurityValue.INVALID_ACCESS_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.INVALID_REFRESH_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.INVALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.INVALID_REFRESH_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;

--- a/src/test/java/net/teumteum/unit/auth/service/AuthServiceTest.java
+++ b/src/test/java/net/teumteum/unit/auth/service/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package net.teumteum.unit.auth.service;
 
 import static net.teumteum.core.security.Authenticated.네이버;
-import static net.teumteum.unit.auth.common.SecurityValue.INVALID_ACCESS_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.INVALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/net/teumteum/unit/common/SecurityValue.java
+++ b/src/test/java/net/teumteum/unit/common/SecurityValue.java
@@ -1,4 +1,4 @@
-package net.teumteum.unit.auth.common;
+package net.teumteum.unit.common;
 
 public final class SecurityValue {
 

--- a/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationEntryPointTest.java
@@ -27,18 +27,15 @@ import org.springframework.security.core.AuthenticationException;
 @DisplayName("JwtAuthenticationEntryPoint 단위 테스트의")
 public class JwtAuthenticationEntryPointTest {
 
+    private static final String ATTRIBUTE_NAME = "exception";
     @Mock
     private ObjectMapper objectMapper;
-
     @Mock
     private AuthenticationException authenticationException;
-
     @Mock
     private HttpServletRequest request;
-
     @Mock
     private HttpServletResponse response;
-
     @InjectMocks
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
@@ -53,7 +50,7 @@ public class JwtAuthenticationEntryPointTest {
             var errorMessage = "Authentication Exception Occurred";
             var outputStream = new ByteArrayOutputStream();
 
-            given(request.getAttribute("exception")).willReturn(errorMessage);
+            given(request.getAttribute(ATTRIBUTE_NAME)).willReturn(errorMessage);
             given(response.getOutputStream()).willReturn(new DelegatingServletOutputStream(outputStream));
 
             // when

--- a/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,67 @@
+package net.teumteum.unit.core.security;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import net.teumteum.core.error.ErrorResponse;
+import net.teumteum.core.security.filter.JwtAuthenticationEntryPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.DelegatingServletOutputStream;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationEntryPoint 단위 테스트의")
+public class JwtAuthenticationEntryPointTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private AuthenticationException authenticationException;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Nested
+    @DisplayName("JwtAuthenticationFilter 에서 인증 예외가 발생시")
+    class When_authentication_error_occurs_from_filter {
+
+        @Test
+        @DisplayName("알맞은 예외 메시지와 관련 응답을 반환한다.")
+        void Return_error_response_with_message() throws IOException {
+            // given
+            var errorMessage = "Authentication Exception Occurred";
+            var outputStream = new ByteArrayOutputStream();
+
+            given(request.getAttribute("exception")).willReturn(errorMessage);
+            given(response.getOutputStream()).willReturn(new DelegatingServletOutputStream(outputStream));
+
+            // when
+            jwtAuthenticationEntryPoint.commence(request, response, authenticationException);
+
+            // then
+            verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            verify(objectMapper, times(1)).writeValue(any(OutputStream.class), any(ErrorResponse.class));
+        }
+    }
+}

--- a/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
@@ -36,21 +36,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 @DisplayName("JwtAuthenticationFilter 단위 테스트의")
 public class JwtAuthenticationFilterTest {
 
+    private static final String ATTRIBUTE_NAME = "exception";
     @Mock
     JwtService jwtService;
-
     @Mock
     AuthService authService;
-
     @Mock
     JwtProperty jwtProperty;
-
     @Mock
     JwtProperty.Access access;
-
     @Mock
     FilterChain filterChain;
-
     @InjectMocks
     JwtAuthenticationFilter jwtAuthenticationFilter;
 
@@ -111,7 +107,7 @@ public class JwtAuthenticationFilterTest {
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
             // then
-            assertThat(request.getAttribute("exception")).isEqualTo("요청에 대한 JWT 가 유효하지 않습니다.");
+            assertThat(request.getAttribute(ATTRIBUTE_NAME)).isEqualTo("요청에 대한 JWT 가 유효하지 않습니다.");
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             assertThat(authentication).isNull();
             verify(filterChain, times(1)).doFilter(request, response);
@@ -135,7 +131,7 @@ public class JwtAuthenticationFilterTest {
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
             // then
-            assertThat(request.getAttribute("exception")).isEqualTo("요청에 대한 JWT 정보가 존재하지 않습니다.");
+            assertThat(request.getAttribute(ATTRIBUTE_NAME)).isEqualTo("요청에 대한 JWT 정보가 존재하지 않습니다.");
             verify(jwtService, times(0)).validateToken(anyString());
         }
     }

--- a/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,142 @@
+package net.teumteum.unit.core.security;
+
+import static net.teumteum.unit.common.SecurityValue.INVALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import net.teumteum.auth.service.AuthService;
+import net.teumteum.core.property.JwtProperty;
+import net.teumteum.core.security.UserAuthentication;
+import net.teumteum.core.security.filter.JwtAuthenticationFilter;
+import net.teumteum.core.security.service.JwtService;
+import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.UserFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationFilter 단위 테스트의")
+public class JwtAuthenticationFilterTest {
+
+    @Mock
+    JwtService jwtService;
+
+    @Mock
+    AuthService authService;
+
+    @Mock
+    JwtProperty jwtProperty;
+
+    @Mock
+    JwtProperty.Access access;
+
+    @Mock
+    FilterChain filterChain;
+
+    @InjectMocks
+    JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Nested
+    @DisplayName("API 요청시 JWT 파싱 및 회원 조회 로직은")
+    class Api_request_with_valid_jwt_unit {
+
+        @BeforeEach
+        @AfterEach
+        void clearSecurityContextHolder() {
+            SecurityContextHolder.clearContext();
+        }
+
+        @Test
+        @DisplayName("유효한 JWT 인 경우, JWT 을 파싱하고 성공적으로 UserAuthentication 을 SecurityContext 에 저장한다.")
+        void Parsing_jwt_and_save_user_in_security_context() throws ServletException, IOException {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            given(jwtProperty.getAccess()).willReturn(access);
+            given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");
+            given(jwtProperty.getBearer()).willReturn("Bearer");
+
+            request.addHeader(jwtProperty.getAccess().getHeader(),
+                jwtProperty.getBearer() + " " + VALID_ACCESS_TOKEN);
+
+            User user = UserFixture.getIdUser();
+
+            given(jwtService.validateToken(anyString())).willReturn(true);
+            given(authService.findUserByAccessToken(anyString())).willReturn(user);
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isInstanceOf(UserAuthentication.class);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 JWT 와 함께 요청이 들어오면, 요청 처리를 중단하고 에러 메세지를 반환한다.")
+        void Return_error_when_jwt_is_invalid() throws ServletException, IOException {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            given(jwtProperty.getAccess()).willReturn(access);
+            given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");
+            given(jwtProperty.getBearer()).willReturn("Bearer");
+
+            request.addHeader(jwtProperty.getAccess().getHeader(),
+                jwtProperty.getBearer() + " " + INVALID_ACCESS_TOKEN);
+
+            given(jwtService.validateToken(anyString())).willReturn(false);
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            assertThat(request.getAttribute("exception")).isEqualTo("요청에 대한 JWT 가 유효하지 않습니다.");
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
+            verify(filterChain, times(1)).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("JWT 가 존재하지 않는 경우, 요청 처리를 중단하고 에러 메세지를 반환한다.")
+        void Return_error_when_jwt_is_not_exist() throws ServletException, IOException {
+            // given
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            given(jwtProperty.getAccess()).willReturn(access);
+            given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");
+            given(jwtProperty.getBearer()).willReturn("Bearer");
+
+            request.addHeader(jwtProperty.getAccess().getHeader(),
+                jwtProperty.getBearer() + " ");
+
+            // when
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // then
+            assertThat(request.getAttribute("exception")).isEqualTo("요청에 대한 JWT 정보가 존재하지 않습니다.");
+            verify(jwtService, times(0)).validateToken(anyString());
+        }
+    }
+}

--- a/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/net/teumteum/unit/core/security/JwtAuthenticationFilterTest.java
@@ -16,7 +16,6 @@ import net.teumteum.core.property.JwtProperty;
 import net.teumteum.core.security.UserAuthentication;
 import net.teumteum.core.security.filter.JwtAuthenticationFilter;
 import net.teumteum.core.security.service.JwtService;
-import net.teumteum.user.domain.User;
 import net.teumteum.user.domain.UserFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,17 +36,17 @@ public class JwtAuthenticationFilterTest {
 
     private static final String ATTRIBUTE_NAME = "exception";
     @Mock
-    JwtService jwtService;
+    private JwtService jwtService;
     @Mock
-    AuthService authService;
+    private AuthService authService;
     @Mock
-    JwtProperty jwtProperty;
+    private JwtProperty jwtProperty;
     @Mock
-    JwtProperty.Access access;
+    private JwtProperty.Access access;
     @Mock
-    FilterChain filterChain;
+    private FilterChain filterChain;
     @InjectMocks
-    JwtAuthenticationFilter jwtAuthenticationFilter;
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Nested
     @DisplayName("API 요청시 JWT 파싱 및 회원 조회 로직은")
@@ -64,8 +62,8 @@ public class JwtAuthenticationFilterTest {
         @DisplayName("유효한 JWT 인 경우, JWT 을 파싱하고 성공적으로 UserAuthentication 을 SecurityContext 에 저장한다.")
         void Parsing_jwt_and_save_user_in_security_context() throws ServletException, IOException {
             // given
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            MockHttpServletResponse response = new MockHttpServletResponse();
+            var request = new MockHttpServletRequest();
+            var response = new MockHttpServletResponse();
 
             given(jwtProperty.getAccess()).willReturn(access);
             given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");
@@ -74,7 +72,7 @@ public class JwtAuthenticationFilterTest {
             request.addHeader(jwtProperty.getAccess().getHeader(),
                 jwtProperty.getBearer() + " " + VALID_ACCESS_TOKEN);
 
-            User user = UserFixture.getIdUser();
+            var user = UserFixture.getIdUser();
 
             given(jwtService.validateToken(anyString())).willReturn(true);
             given(authService.findUserByAccessToken(anyString())).willReturn(user);
@@ -83,7 +81,7 @@ public class JwtAuthenticationFilterTest {
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
             // then
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
             assertThat(authentication).isInstanceOf(UserAuthentication.class);
         }
 
@@ -91,8 +89,8 @@ public class JwtAuthenticationFilterTest {
         @DisplayName("유효하지 않은 JWT 와 함께 요청이 들어오면, 요청 처리를 중단하고 에러 메세지를 반환한다.")
         void Return_error_when_jwt_is_invalid() throws ServletException, IOException {
             // given
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            MockHttpServletResponse response = new MockHttpServletResponse();
+            var request = new MockHttpServletRequest();
+            var response = new MockHttpServletResponse();
 
             given(jwtProperty.getAccess()).willReturn(access);
             given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");
@@ -108,7 +106,7 @@ public class JwtAuthenticationFilterTest {
 
             // then
             assertThat(request.getAttribute(ATTRIBUTE_NAME)).isEqualTo("요청에 대한 JWT 가 유효하지 않습니다.");
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
             assertThat(authentication).isNull();
             verify(filterChain, times(1)).doFilter(request, response);
         }
@@ -117,8 +115,8 @@ public class JwtAuthenticationFilterTest {
         @DisplayName("JWT 가 존재하지 않는 경우, 요청 처리를 중단하고 에러 메세지를 반환한다.")
         void Return_error_when_jwt_is_not_exist() throws ServletException, IOException {
             // given
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            MockHttpServletResponse response = new MockHttpServletResponse();
+            var request = new MockHttpServletRequest();
+            var response = new MockHttpServletResponse();
 
             given(jwtProperty.getAccess()).willReturn(access);
             given(jwtProperty.getAccess().getHeader()).willReturn("Authorization");

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -1,7 +1,7 @@
 package net.teumteum.unit.user.controller;
 
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static net.teumteum.user.domain.Review.별로에요;
 import static net.teumteum.user.domain.Review.최고에요;
 import static org.hamcrest.Matchers.hasSize;
@@ -267,11 +267,9 @@ public class UserControllerTest {
     class Logout_user_api_unit {
 
         @Test
-        @DisplayName("")
+        @DisplayName("로그인한 회원의 로그아웃을 진행하고, 200 OK 을 반환합니다.")
         void Logout_user_with_200_ok() throws Exception {
             // given
-            var userId = 1L;
-
             doNothing().when(userService).logout(anyLong());
 
             // when && then

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -1,7 +1,8 @@
 package net.teumteum.unit.user.service;
 
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_ACCESS_TOKEN;
-import static net.teumteum.unit.auth.common.SecurityValue.VALID_REFRESH_TOKEN;
+
+import static net.teumteum.unit.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static net.teumteum.unit.common.SecurityValue.VALID_REFRESH_TOKEN;
 import static net.teumteum.user.domain.Review.별로에요;
 import static net.teumteum.user.domain.Review.최고에요;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- JWT 관련 인증 단위 태스트을 구현하고 테스트 합니다.
## 🕶️ 어떻게 해결했나요?
- [x] JwtAuthenticationFilterTest 구현
     - api 요청시 헤더를 통해 전달되는 JWT 인증 관련 단위 테스트
- [x] JwtAuthenticationEntryPointTest 구현 
     - api 요청시 Authentication Exception 발생시 호출되는 인증 실패 로직 관련 단위 테스트
- [x] 불필요한 인증 로직 제거

## 🦀 이슈 넘버
- close #198 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
