### PR TITLE
feat: 기존 회원 리뷰 조회 API 로직 변경

### DIFF
--- a/src/main/java/net/teumteum/user/controller/UserController.java
+++ b/src/main/java/net/teumteum/user/controller/UserController.java
@@ -116,10 +116,10 @@ public class UserController {
         userService.registerReview(meetingId, getCurrentUserId(), request);
     }
 
-    @GetMapping("/reviews")
+    @GetMapping("/{userId}/reviews")
     @ResponseStatus(HttpStatus.OK)
-    public List<UserReviewsResponse> getUserReviews() {
-        return userService.getUserReviews(getCurrentUserId());
+    public UserReviewsResponse getUserReviews(@PathVariable("userId") Long userId) {
+        return userService.getUserReviews(userId);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/net/teumteum/user/domain/UserRepository.java
+++ b/src/main/java/net/teumteum/user/domain/UserRepository.java
@@ -3,7 +3,7 @@ package net.teumteum.user.domain;
 import java.util.List;
 import java.util.Optional;
 import net.teumteum.core.security.Authenticated;
-import net.teumteum.user.domain.response.UserReviewsResponse;
+import net.teumteum.user.domain.response.UserReviewResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByAuthenticatedAndOAuthId(@Param("authenticated") Authenticated authenticated,
         @Param("oAuthId") String oAuthId);
 
-    @Query("select new net.teumteum.user.domain.response.UserReviewsResponse(r,count(r)) "
-        + "from users u join u.reviews r where u.id = :userId group by r")
-    List<UserReviewsResponse> countUserReviewsByUserId(@Param("userId") Long userId);
+    @Query("select new net.teumteum.user.domain.response.UserReviewResponse(r, count(r)) "
+        + "from users u join u.reviews r where u = :user group by r")
+    List<UserReviewResponse> countUserReviewsByUser(@Param("user") User user);
+
 }

--- a/src/main/java/net/teumteum/user/domain/response/UserReviewResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserReviewResponse.java
@@ -1,0 +1,10 @@
+package net.teumteum.user.domain.response;
+
+import net.teumteum.user.domain.Review;
+
+public record UserReviewResponse(
+    Review review,
+    long count
+) {
+
+}

--- a/src/main/java/net/teumteum/user/domain/response/UserReviewsResponse.java
+++ b/src/main/java/net/teumteum/user/domain/response/UserReviewsResponse.java
@@ -1,10 +1,12 @@
 package net.teumteum.user.domain.response;
 
-import net.teumteum.user.domain.Review;
+import java.util.List;
 
 public record UserReviewsResponse(
-    Review review,
-    long count
+    List<UserReviewResponse> reviews
 ) {
 
+    public static UserReviewsResponse of(List<UserReviewResponse> reviews) {
+        return new UserReviewsResponse(reviews);
+    }
 }

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -116,8 +116,10 @@ public class UserService {
             });
     }
 
-    public List<UserReviewsResponse> getUserReviews(Long userId) {
-        return userRepository.countUserReviewsByUserId(userId);
+    public UserReviewsResponse getUserReviews(Long userId) {
+        var user = getUser(userId);
+
+        return UserReviewsResponse.of(userRepository.countUserReviewsByUser(user));
     }
 
     public FriendsResponse findFriendsByUserId(Long userId) {

--- a/src/test/java/net/teumteum/integration/Api.java
+++ b/src/test/java/net/teumteum/integration/Api.java
@@ -196,10 +196,10 @@ class Api {
             .exchange();
     }
 
-    ResponseSpec getUserReviews(String accessToken) {
+    ResponseSpec getUserReviews(Long userId, String accessToken) {
         return webTestClient
             .get()
-            .uri("/users/reviews")
+            .uri("/users/" + userId + "/reviews")
             .header(HttpHeaders.AUTHORIZATION, accessToken)
             .exchange();
     }

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -346,10 +346,12 @@ class UserIntegrationTest extends IntegrationTest {
             // given
             var existUser = repository.saveAndGetUser();
 
+            var userId = existUser.getId();
+
             securityContextSetting.set(existUser.getId());
 
             // when
-            var expected = api.getUserReviews(VALID_TOKEN);
+            var expected = api.getUserReviews(userId, VALID_TOKEN);
 
             // then
             Assertions.assertThat(expected.expectStatus().isOk()

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -37,6 +37,7 @@ import net.teumteum.user.domain.request.ReviewRegisterRequest;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserWithdrawRequest;
 import net.teumteum.user.domain.response.UserRegisterResponse;
+import net.teumteum.user.domain.response.UserReviewResponse;
 import net.teumteum.user.domain.response.UserReviewsResponse;
 import net.teumteum.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -238,27 +239,25 @@ public class UserControllerTest {
     class Get_user_reviews_api_unit {
 
         @Test
-        @DisplayName("로그인한 회원 id 에 해당하는 회원 리뷰와 200 OK을 반환한다.")
+        @DisplayName("user id 에 해당하는 회원 리뷰와 200 OK을 반환한다.")
         void Get_user_reviews_with_200_ok() throws Exception {
             // given
             var userId = 1L;
 
-            given(securityService.getCurrentUserId()).willReturn(userId);
-
             given(userService.getUserReviews(anyLong()))
-                .willReturn(List.of(new UserReviewsResponse(별로에요, 2L),
-                    new UserReviewsResponse(최고에요, 3L)));
+                .willReturn(UserReviewsResponse.of(List.of(new UserReviewResponse(별로에요, 2L),
+                    new UserReviewResponse(최고에요, 3L))));
 
             // when & then
-            mockMvc.perform(get("/users/reviews")
+            mockMvc.perform(get("/users/{userId}/reviews", 1)
                     .with(csrf())
                     .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", notNullValue()))
-                .andExpect(jsonPath("$", hasSize(2)))
-                .andExpect(jsonPath("$[0].count", is(2)))
-                .andExpect(jsonPath("$[0].review").value("별로에요"));
+                .andExpect(jsonPath("$.reviews", notNullValue()))
+                .andExpect(jsonPath("$.reviews", hasSize(2)))
+                .andExpect(jsonPath("$.reviews[0].count", is(2)))
+                .andExpect(jsonPath("$.reviews[0].review").value("별로에요"));
         }
     }
 

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -30,7 +30,7 @@ import net.teumteum.user.domain.request.ReviewRegisterRequest;
 import net.teumteum.user.domain.request.UserRegisterRequest;
 import net.teumteum.user.domain.request.UserWithdrawRequest;
 import net.teumteum.user.domain.response.UserRegisterResponse;
-import net.teumteum.user.domain.response.UserReviewsResponse;
+import net.teumteum.user.domain.response.UserReviewResponse;
 import net.teumteum.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -251,23 +251,24 @@ public class UserServiceTest {
         void Return_user_reviews_with_200_ok() {
             // given
             var userId = 1L;
+            var existUser = UserFixture.getIdUser();
 
-            var response = List.of(new UserReviewsResponse(최고에요, 2L)
-                , new UserReviewsResponse(별로에요, 3L));
+            var response = List.of(new UserReviewResponse(최고에요, 2L)
+                , new UserReviewResponse(별로에요, 3L));
 
-            given(userRepository.countUserReviewsByUserId(anyLong())).willReturn(response);
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(existUser));
+            given(userRepository.countUserReviewsByUser(any(User.class))).willReturn(response);
 
             // when
             var result = userService.getUserReviews(userId);
 
             // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).review()).isEqualTo(최고에요);
-            assertThat(result.get(0).count()).isEqualTo(2L);
-            assertThat(result.get(1).review()).isEqualTo(별로에요);
-            assertThat(result.get(1).count()).isEqualTo(3L);
+            assertThat(result.reviews()).hasSize(2);
+            assertThat(result.reviews().get(0).review()).isEqualTo(최고에요);
+            assertThat(result.reviews().get(0).count()).isEqualTo(2L);
+            assertThat(result.reviews().get(1).review()).isEqualTo(별로에요);
 
-            verify(userRepository, times(1)).countUserReviewsByUserId(anyLong());
+            verify(userRepository, times(1)).countUserReviewsByUser(any(User.class));
         }
     }
 }

--- a/src/test/java/net/teumteum/user/domain/UserRepositoryTest.java
+++ b/src/test/java/net/teumteum/user/domain/UserRepositoryTest.java
@@ -7,7 +7,7 @@ import static net.teumteum.user.domain.Review.최고에요;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import net.teumteum.core.config.AppConfig;
-import net.teumteum.user.domain.response.UserReviewsResponse;
+import net.teumteum.user.domain.response.UserReviewResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -85,13 +85,14 @@ class UserRepositoryTest {
             entityManager.clear();
 
             // when
-            var result = userRepository.countUserReviewsByUserId(id);
+            var result = userRepository.countUserReviewsByUser(existUser);
 
             // then
             Assertions.assertThat(result)
                 .isNotEmpty()
                 .hasSize(3)
-                .extracting(UserReviewsResponse::review, UserReviewsResponse::count)
+                .extracting(UserReviewResponse::review,
+                    UserReviewResponse::count)
                 .contains(
                     Assertions.tuple(최고에요, 3L),
                     Assertions.tuple(별로에요, 1L),


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 현재 로그인한 회원의 리뷰 조회 로직에서 userId 에 해당하는 회원의 리뷰 조회 로직으로 변경

## 🕶️ 어떻게 해결했나요?
- [x] api 로직 변경
- [x] 응답 구조 변경
- [x] 단위,통합 테스트 변경 

## 🦀 이슈 넘버
- close #217 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
