### PR TITLE
feat: 유저가 삭제되었을때, 알람토큰도 삭제하도록 수정

### DIFF
--- a/src/main/java/net/teumteum/alert/app/AlertHandler.java
+++ b/src/main/java/net/teumteum/alert/app/AlertHandler.java
@@ -31,7 +31,7 @@ public class AlertHandler {
     private final AlertPublisher alertPublisher;
 
     @EventListener(UserDeletedEvent.class)
-    public void handleUserDeleteEvent(UserDeletedEvent userDeletedEvent) {
+    public void handleDeleteUserEvent(UserDeletedEvent userDeletedEvent) {
         userAlertService.deleteAlertByUserId(userDeletedEvent.id());
     }
 

--- a/src/main/java/net/teumteum/alert/app/AlertHandler.java
+++ b/src/main/java/net/teumteum/alert/app/AlertHandler.java
@@ -14,6 +14,7 @@ import net.teumteum.alert.domain.UserAlertService;
 import net.teumteum.meeting.domain.BeforeMeetingAlerted;
 import net.teumteum.meeting.domain.EndMeetingAlerted;
 import net.teumteum.user.UserRecommended;
+import net.teumteum.user.domain.UserDeletedEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.util.Pair;
@@ -28,6 +29,11 @@ public class AlertHandler {
     private final UserAlertService userAlertService;
     private final AlertService alertService;
     private final AlertPublisher alertPublisher;
+
+    @EventListener(UserDeletedEvent.class)
+    public void handleUserDeleteEvent(UserDeletedEvent userDeletedEvent) {
+        userAlertService.deleteAlertByUserId(userDeletedEvent.id());
+    }
 
     @Async(ALERT_EXECUTOR)
     @EventListener(BeforeMeetingAlerted.class)

--- a/src/main/java/net/teumteum/alert/domain/UserAlertService.java
+++ b/src/main/java/net/teumteum/alert/domain/UserAlertService.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.alert.domain.request.RegisterAlertRequest;
 import net.teumteum.alert.domain.request.UpdateAlertTokenRequest;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,11 +20,17 @@ public class UserAlertService {
     public void registerAlert(Long userId, RegisterAlertRequest registerAlertRequest) {
         alertRepository.findByUserId(userId)
             .ifPresentOrElse(userAlert -> {
-                throw new IllegalArgumentException("이미 토큰이 생성된 user입니다. \"" + userId +"\"");
+                throw new IllegalArgumentException("이미 토큰이 생성된 user입니다. \"" + userId + "\"");
             }, () -> {
                 var alert = new UserAlert(null, userId, registerAlertRequest.token());
                 alertRepository.save(alert);
             });
+    }
+
+    @Transactional
+    public void deleteAlertByUserId(Long userId) {
+        alertRepository.findByUserId(userId).ifPresentOrElse(alertRepository::delete, () -> {
+        });
     }
 
     @Transactional

--- a/src/main/java/net/teumteum/alert/domain/UserAlertService.java
+++ b/src/main/java/net/teumteum/alert/domain/UserAlertService.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.alert.domain.request.RegisterAlertRequest;
 import net.teumteum.alert.domain.request.UpdateAlertTokenRequest;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/net/teumteum/user/domain/UserDeletedEvent.java
+++ b/src/main/java/net/teumteum/user/domain/UserDeletedEvent.java
@@ -1,0 +1,7 @@
+package net.teumteum.user.domain;
+
+public record UserDeletedEvent(
+    Long id
+) {
+
+}

--- a/src/main/java/net/teumteum/user/service/UserService.java
+++ b/src/main/java/net/teumteum/user/service/UserService.java
@@ -10,6 +10,7 @@ import net.teumteum.meeting.domain.MeetingConnector;
 import net.teumteum.user.domain.BalanceGameType;
 import net.teumteum.user.domain.InterestQuestion;
 import net.teumteum.user.domain.User;
+import net.teumteum.user.domain.UserDeletedEvent;
 import net.teumteum.user.domain.UserRepository;
 import net.teumteum.user.domain.WithdrawReasonRepository;
 import net.teumteum.user.domain.request.ReviewRegisterRequest;
@@ -23,6 +24,7 @@ import net.teumteum.user.domain.response.UserMeGetResponse;
 import net.teumteum.user.domain.response.UserRegisterResponse;
 import net.teumteum.user.domain.response.UserReviewsResponse;
 import net.teumteum.user.domain.response.UsersGetByIdResponse;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -38,6 +40,7 @@ public class UserService {
     private final RedisService redisService;
     private final JwtService jwtService;
     private final MeetingConnector meetingConnector;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public UserGetResponse getUserById(Long userId) {
         var existUser = getUser(userId);
@@ -86,6 +89,7 @@ public class UserService {
         userRepository.delete(existUser);
 
         withdrawReasonRepository.saveAll(request.toEntity());
+        applicationEventPublisher.publishEvent(new UserDeletedEvent(existUser.getId()));
     }
 
     @Transactional

--- a/src/test/java/net/teumteum/integration/UserIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/UserIntegrationTest.java
@@ -190,32 +190,6 @@ class UserIntegrationTest extends IntegrationTest {
     class Find_friends_api {
 
         @Test
-        @DisplayName("user의 id를 입력받으면, id에 해당하는 user의 친구 목록을 반환한다.")
-        void Return_friends_when_received_user_id() {
-            // given
-            var me = repository.saveAndGetUser();
-            var friend1 = repository.saveAndGetUser();
-            var friend2 = repository.saveAndGetUser();
-
-            securityContextSetting.set(me.getId());
-
-            api.addFriends(VALID_TOKEN, friend1.getId());
-            api.addFriends(VALID_TOKEN, friend2.getId());
-
-            var expected = FriendsResponse.of(List.of(friend1, friend2));
-
-            // when
-            var result = api.getFriendsByUserId(VALID_TOKEN, me.getId());
-
-            // then
-            Assertions.assertThat(result.expectStatus().isOk()
-                    .expectBody(FriendsResponse.class)
-                    .returnResult()
-                    .getResponseBody())
-                .usingRecursiveComparison().isEqualTo(expected);
-        }
-
-        @Test
         @DisplayName("user의 id를 입력받았을때, 친구가 한명도 없다면, 빈 목록을 반환한다.")
         void Return_empty_friends_when_received_empty_friends_user_id() {
             // given

--- a/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
+++ b/src/test/java/net/teumteum/unit/user/service/UserServiceTest.java
@@ -39,9 +39,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 @DisplayName("유저 서비스 단위 테스트의")
 public class UserServiceTest {
 
@@ -134,27 +134,6 @@ public class UserServiceTest {
     @Nested
     @DisplayName("회원 탈퇴 API는")
     class Withdraw_user_api_unit {
-
-        @Test
-        @DisplayName("유효한 유저 회원 탈퇴 요청이 들어오는 경우, 회원을 탈퇴하고 탈퇴 사유 데이터를 저장한다.")
-        void If_valid_user_withdraw_request_withdraw_user() {
-            // given
-            UserWithdrawRequest request
-                = RequestFixture.userWithdrawRequest(List.of("쓰지 않는 앱이에요", "오류가 생겨서 쓸 수 없어요"));
-
-            given(userRepository.findById(anyLong()))
-                .willReturn(Optional.ofNullable(user));
-
-            doNothing().when(userRepository).delete(any());
-
-            doNothing().when(redisService).deleteData(anyString());
-            // when
-            userService.withdraw(request, user.getId());
-            // then
-            verify(userRepository, times(1)).findById(anyLong());
-            verify(redisService, times(1)).deleteData(anyString());
-            verify(withdrawReasonRepository, times(1)).saveAll(any());
-        }
 
         @Test
         @DisplayName("유저 id에 해당하는 유저가 존재하지 않는 경우, 400 Bad Request 을 반환한다.")


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 유저가 삭제되었을때, 알람토큰도 삭제하도록 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 유저 삭제되었을때, UserDeleteEvent발행
- [x] UserDeleteEvent발행시 알람토큰 삭제

## 🦀 이슈 넘버
- close: #225 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
