### PR TITLE
feat: 리뷰 등록시 모임 참여 유저 조회 API 수정

### DIFF
--- a/src/main/java/net/teumteum/meeting/controller/MeetingController.java
+++ b/src/main/java/net/teumteum/meeting/controller/MeetingController.java
@@ -9,7 +9,7 @@ import net.teumteum.core.security.service.SecurityService;
 import net.teumteum.meeting.domain.Topic;
 import net.teumteum.meeting.domain.request.CreateMeetingRequest;
 import net.teumteum.meeting.domain.request.UpdateMeetingRequest;
-import net.teumteum.meeting.domain.response.MeetingParticipantsResponse;
+import net.teumteum.meeting.domain.response.MeetingParticipantResponse;
 import net.teumteum.meeting.domain.response.MeetingResponse;
 import net.teumteum.meeting.domain.response.MeetingsResponse;
 import net.teumteum.meeting.model.PageDto;
@@ -43,14 +43,14 @@ public class MeetingController {
     public MeetingResponse createMeeting(
         @RequestPart @Valid CreateMeetingRequest meetingRequest,
         @RequestPart List<MultipartFile> images) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         return meetingService.createMeeting(images, meetingRequest, userId);
     }
 
     @GetMapping("/{meetingId}")
     @ResponseStatus(HttpStatus.OK)
     public MeetingResponse getMeetingById(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         return meetingService.getMeetingById(meetingId, userId);
     }
 
@@ -64,7 +64,7 @@ public class MeetingController {
         @RequestParam(value = "participantUserId", required = false) Long participantUserId,
         @RequestParam(value = "isBookmarked", required = false) Boolean isBookmarked,
         @RequestParam(value = "searchWord", required = false) String searchWord) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         return meetingService.getMeetingsBySpecification(pageable, topic, meetingAreaStreet, participantUserId,
             searchWord, isBookmarked, isOpen, userId);
     }
@@ -74,55 +74,56 @@ public class MeetingController {
     public MeetingResponse updateMeeting(@PathVariable Long meetingId,
         @RequestPart @Valid UpdateMeetingRequest request,
         @RequestPart List<MultipartFile> images) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         return meetingService.updateMeeting(meetingId, images, request, userId);
     }
 
     @DeleteMapping("/{meetingId}")
     @ResponseStatus(HttpStatus.OK)
     public void deleteMeeting(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         meetingService.deleteMeeting(meetingId, userId);
     }
 
     @PostMapping("/{meetingId}/participants")
     @ResponseStatus(HttpStatus.CREATED)
     public MeetingResponse addParticipant(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         return meetingService.addParticipant(meetingId, userId);
     }
 
     @DeleteMapping("/{meetingId}/participants")
     @ResponseStatus(HttpStatus.OK)
     public void deleteParticipant(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         meetingService.cancelParticipant(meetingId, userId);
     }
 
     @GetMapping("/{meetingId}/participants")
     @ResponseStatus(HttpStatus.OK)
-    public List<MeetingParticipantsResponse> getParticipants(@PathVariable("meetingId") Long meetingId) {
-        return meetingService.getParticipants(meetingId);
+    public List<MeetingParticipantResponse> getParticipants(@PathVariable("meetingId") Long meetingId) {
+        Long userId = getCurrentUserId();
+        return meetingService.getParticipants(meetingId, userId);
     }
 
     @PostMapping("/{meetingId}/reports")
     @ResponseStatus(HttpStatus.CREATED)
     public void reportMeeting(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         meetingService.reportMeeting(meetingId, userId);
     }
 
     @PostMapping("/{meetingId}/bookmarks")
     @ResponseStatus(HttpStatus.CREATED)
     public void addBookmark(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         meetingService.addBookmark(meetingId, userId);
     }
 
     @DeleteMapping("/{meetingId}/bookmarks")
     @ResponseStatus(HttpStatus.OK)
     public void deleteBookmark(@PathVariable("meetingId") Long meetingId) {
-        Long userId = securityService.getCurrentUserId();
+        Long userId = getCurrentUserId();
         meetingService.cancelBookmark(meetingId, userId);
     }
 
@@ -131,5 +132,9 @@ public class MeetingController {
     public ErrorResponse handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {
         Sentry.captureException(illegalArgumentException);
         return ErrorResponse.of(illegalArgumentException);
+    }
+
+    private Long getCurrentUserId() {
+        return securityService.getCurrentUserId();
     }
 }

--- a/src/main/java/net/teumteum/meeting/domain/response/MeetingParticipantResponse.java
+++ b/src/main/java/net/teumteum/meeting/domain/response/MeetingParticipantResponse.java
@@ -2,17 +2,17 @@ package net.teumteum.meeting.domain.response;
 
 import net.teumteum.user.domain.User;
 
-public record MeetingParticipantsResponse(
+public record MeetingParticipantResponse(
     Long id,
     Long characterId,
     String name,
     String job
 ) {
 
-    public static MeetingParticipantsResponse of(
+    public static MeetingParticipantResponse of(
         User user
     ) {
-        return new MeetingParticipantsResponse(
+        return new MeetingParticipantResponse(
             user.getId(),
             user.getCharacterId(),
             user.getName(),

--- a/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
+++ b/src/test/java/net/teumteum/integration/MeetingIntegrationTest.java
@@ -1,7 +1,10 @@
 package net.teumteum.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 import net.teumteum.core.error.ErrorResponse;
 import net.teumteum.meeting.domain.Meeting;
@@ -9,7 +12,6 @@ import net.teumteum.meeting.domain.Topic;
 import net.teumteum.meeting.domain.response.MeetingResponse;
 import net.teumteum.meeting.domain.response.MeetingsResponse;
 import net.teumteum.meeting.model.PageDto;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,10 +44,10 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingById(VALID_TOKEN, meeting.getId());
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(MeetingResponse.class)
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(MeetingResponse.class)
+                    .returnResult().getResponseBody())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
         }
@@ -75,10 +77,10 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingById(VALID_TOKEN, meeting.getId());
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(MeetingResponse.class)
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(MeetingResponse.class)
+                    .returnResult().getResponseBody())
                 .extracting(MeetingResponse::isBookmarked)
                 .isEqualTo(true);
         }
@@ -158,11 +160,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingsByTopic(VALID_TOKEN, FIRST_PAGE_NATION, true, Topic.스터디);
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
-                        })
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
+                    })
+                    .returnResult().getResponseBody())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
         }
@@ -192,11 +194,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingsByTopic(VALID_TOKEN, FIRST_PAGE_NATION, true, Topic.스터디);
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
-                        })
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
+                    })
+                    .returnResult().getResponseBody())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
         }
@@ -222,11 +224,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingsByTopic(VALID_TOKEN, FIRST_PAGE_NATION, true, Topic.스터디);
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
-                        })
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
+                    })
+                    .returnResult().getResponseBody())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
         }
@@ -252,11 +254,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.getMeetingsByTopic(VALID_TOKEN, FIRST_PAGE_NATION, true, Topic.스터디);
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isOk()
-                        .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
-                        })
-                        .returnResult().getResponseBody())
+            assertThat(
+                result.expectStatus().isOk()
+                    .expectBody(new ParameterizedTypeReference<PageDto<MeetingsResponse>>() {
+                    })
+                    .returnResult().getResponseBody())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
         }
@@ -277,11 +279,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.joinMeeting(VALID_TOKEN, existMeeting.getId());
             // then
-            Assertions.assertThat(
-                    result.expectStatus().isCreated()
-                        .expectBody(MeetingResponse.class)
-                        .returnResult()
-                        .getResponseBody())
+            assertThat(
+                result.expectStatus().isCreated()
+                    .expectBody(MeetingResponse.class)
+                    .returnResult()
+                    .getResponseBody())
                 .extracting(MeetingResponse::participantIds)
                 .has(new Condition<>(ids -> ids.contains(me.getId()), "참여자 목록에 나를 포함한다.")
                 );
@@ -380,11 +382,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.cancelMeeting(VALID_TOKEN, meeting.getId());
             // then
-            Assertions.assertThat(result.expectStatus().isBadRequest()
-                    .expectBody(ErrorResponse.class)
-                    .returnResult()
-                    .getResponseBody()
-                )
+            assertThat(result.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult()
+                .getResponseBody()
+            )
                 .extracting(ErrorResponse::getMessage)
                 .isEqualTo("참여하지 않은 모임입니다.");
         }
@@ -400,11 +402,11 @@ class MeetingIntegrationTest extends IntegrationTest {
             // when
             var result = api.cancelMeeting(VALID_TOKEN, meeting.getId());
             // then
-            Assertions.assertThat(result.expectStatus().isBadRequest()
-                    .expectBody(ErrorResponse.class)
-                    .returnResult()
-                    .getResponseBody()
-                )
+            assertThat(result.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult()
+                .getResponseBody()
+            )
                 .extracting(ErrorResponse::getMessage)
                 .isEqualTo("종료된 모임에서 참여를 취소할 수 없습니다.");
         }
@@ -488,11 +490,37 @@ class MeetingIntegrationTest extends IntegrationTest {
         @DisplayName("참여한 meeting id 가 주어지면, 참여한 참가자들의 정보가 주어진다.")
         void Get_participants_if_exist_meeting_id_received() {
             // given
-            var meeting = repository.saveAndGetOpenMeeting();
+            var me = repository.saveAndGetUser();
+            var meeting = repository.saveAndGetClosedMetingWithParticipantUserIds(List.of(me.getId(), 2L));
+
+            securityContextSetting.set(me.getId());
+
             // when
             var result = api.getMeetingParticipants(VALID_TOKEN, meeting.getId());
+
             // then
             result.expectStatus().isOk();
+        }
+
+        @Test
+        @DisplayName("API 호출한 회원이 모임에 참여하지 않았다면, 400 bad request 을 응답한다.")
+        void Return_400_bad_request_if_meeting_not_contain_user() {
+            // given
+            var me = repository.saveAndGetUser();
+            var meeting = repository.saveAndGetClosedMetingWithParticipantUserIds(List.of(100L, 101L));
+
+            securityContextSetting.set(me.getId());
+
+            // when
+            var result = api.getMeetingParticipants(VALID_TOKEN, meeting.getId());
+
+            // then
+            assertThat(result.expectStatus().isBadRequest()
+                .expectBody(ErrorResponse.class)
+                .returnResult()
+                .getResponseBody())
+                .extracting(ErrorResponse::getMessage)
+                .isEqualTo("모임에 참여하지 않은 회원입니다.");
         }
     }
 }

--- a/src/test/java/net/teumteum/integration/Repository.java
+++ b/src/test/java/net/teumteum/integration/Repository.java
@@ -2,7 +2,6 @@ package net.teumteum.integration;
 
 
 import java.util.List;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import net.teumteum.core.config.AppConfig;
@@ -82,6 +81,11 @@ public class Repository {
         return meetingRepository.saveAndFlush(meeting);
     }
 
+    Meeting saveAndGetClosedMetingWithParticipantUserIds(List<Long> participantUserIds) {
+        var meeting = MeetingFixture.getCloseMeetingWithParticipantUserIds(participantUserIds);
+        return meetingRepository.saveAndFlush(meeting);
+    }
+
     List<Meeting> saveAndGetOpenMeetingsByTopic(int size, Topic topic) {
         var meetings = Stream.generate(() -> MeetingFixture.getOpenMeetingWithTopic(topic))
             .limit(size)
@@ -145,6 +149,7 @@ public class Repository {
             .toList();
         return meetingRepository.saveAllAndFlush(meetings);
     }
+
 
     void clear() {
         userRepository.deleteAll();

--- a/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
+++ b/src/test/java/net/teumteum/meeting/domain/MeetingFixture.java
@@ -82,6 +82,14 @@ public class MeetingFixture {
         );
     }
 
+    public static Meeting getCloseMeetingWithParticipantUserIds(List<Long> participantUserIds) {
+        return newMeetingByBuilder(MeetingBuilder.builder()
+            .promiseDateTime(LocalDateTime.of(2000, 1, 1, 0, 0))
+            .participantUserIds(new HashSet<>(participantUserIds))
+            .build()
+        );
+    }
+
     public static Meeting getOpenMeetingWithTitle(String title) {
         return newMeetingByBuilder(MeetingBuilder.builder()
             .promiseDateTime(LocalDateTime.of(4000, 1, 1, 0, 0))

--- a/src/test/java/net/teumteum/unit/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/net/teumteum/unit/meeting/controller/MeetingControllerTest.java
@@ -1,0 +1,112 @@
+package net.teumteum.unit.meeting.controller;
+
+import static net.teumteum.unit.common.SecurityValue.VALID_ACCESS_TOKEN;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import net.teumteum.core.security.SecurityConfig;
+import net.teumteum.core.security.filter.JwtAuthenticationFilter;
+import net.teumteum.core.security.service.JwtService;
+import net.teumteum.core.security.service.RedisService;
+import net.teumteum.core.security.service.SecurityService;
+import net.teumteum.meeting.controller.MeetingController;
+import net.teumteum.meeting.domain.response.MeetingParticipantResponse;
+import net.teumteum.meeting.service.MeetingService;
+import net.teumteum.user.domain.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = MeetingController.class,
+    excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RedisService.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtService.class)}
+)
+@WithMockUser
+@DisplayName("모임 컨트롤러 단위 테스트의")
+public class MeetingControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MeetingService meetingService;
+
+    @MockBean
+    private SecurityService securityService;
+
+    @Nested
+    @DisplayName("모임 참여자 조회 API는")
+    class Get_meeting_participants_api_unit {
+
+        @Test
+        @DisplayName("API 호출 회원을 제외한, meetingId 해당하는 모임의 참여자 정보를 반환한다.")
+        void Return_meeting_participants_with_200_ok() throws Exception {
+            // given
+            var existUser1 = UserFixture.getUserWithId(1L);
+            var existUser2 = UserFixture.getUserWithId(2L);
+            var existUser3 = UserFixture.getUserWithId(3L);
+
+            List<MeetingParticipantResponse> response
+                = List.of(MeetingParticipantResponse.of(existUser2), MeetingParticipantResponse.of(existUser3));
+
+            given(securityService.getCurrentUserId())
+                .willReturn(existUser1.getId());
+
+            given(meetingService.getParticipants(anyLong(), anyLong()))
+                .willReturn(response);
+
+            // when && then
+            mockMvc.perform(get("/meetings/{meetingId}/participants", 2L)
+                    .with(csrf())
+                    .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isNotEmpty())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(2))
+                .andExpect(jsonPath("$[0].characterId").value(1));
+        }
+
+        @Test
+        @DisplayName("모임에 API 호출 회원이 존재하지 않는 경우, 400 bad request를 응답한다.")
+        void Return_400_bad_request_if_meeting_not_contain_user() throws Exception {
+            // given
+            var existUser1 = UserFixture.getUserWithId(1L);
+
+            given(securityService.getCurrentUserId())
+                .willReturn(existUser1.getId());
+
+            given(meetingService.getParticipants(anyLong(), anyLong())).willThrow(
+                new IllegalArgumentException("모임에 참여하지 않은 회원입니다."));
+
+            // when & then
+            mockMvc.perform(get("/meetings/{meetingId}/participants", 2L)
+                    .with(csrf())
+                    .header(AUTHORIZATION, VALID_ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("모임에 참여하지 않은 회원입니다."));
+        }
+    }
+}

--- a/src/test/java/net/teumteum/unit/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/net/teumteum/unit/meeting/service/MeetingServiceTest.java
@@ -1,0 +1,91 @@
+package net.teumteum.unit.meeting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+import net.teumteum.meeting.domain.ImageUpload;
+import net.teumteum.meeting.domain.MeetingFixture;
+import net.teumteum.meeting.domain.MeetingRepository;
+import net.teumteum.meeting.domain.response.MeetingParticipantResponse;
+import net.teumteum.meeting.service.MeetingService;
+import net.teumteum.user.domain.UserConnector;
+import net.teumteum.user.domain.UserFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("모임 서비스 단위 테스트의")
+public class MeetingServiceTest {
+
+    @InjectMocks
+    MeetingService meetingService;
+
+    @Mock
+    MeetingRepository meetingRepository;
+
+    @Mock
+    UserConnector userConnector;
+
+    @Mock
+    ImageUpload imageUpload;
+
+    @Nested
+    @DisplayName("모임 참여자 조회 API는")
+    class Return_meeting_participants_api_unit {
+
+        @Test
+        @DisplayName("API 호출 회원을 제외한, meetingId 해당하는 모임의 참여자 정보를 반환한다.")
+        void Return_meeting_participants_with_200_ok() {
+            // given
+            var userId = 1L;
+            var meetingId = 1L;
+
+            var existMeeting
+                = MeetingFixture.getCloseMeetingWithParticipantUserIds(List.of(userId, 2L, 3L));
+
+            var existUser2 = UserFixture.getUserWithId(2L);
+            var existUser3 = UserFixture.getUserWithId(3L);
+
+            given(meetingRepository.findById(anyLong()))
+                .willReturn(Optional.of(existMeeting));
+
+            given(userConnector.findUserById(existUser2.getId())).willReturn(Optional.of(existUser2));
+            given(userConnector.findUserById(existUser3.getId())).willReturn(Optional.of(existUser3));
+
+            // when
+            List<MeetingParticipantResponse> participants = meetingService.getParticipants(meetingId, userId);
+            // then
+            assertThat(participants).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("모임에 API 호출 회원이 존재하지 않는 경우, 400 bad request를 응답한다.")
+        void Return_400_bad_request_if_meeting_not_contain_user() {
+            // given
+            var userId = 1L;
+            var notContainedUserId = 4L;
+
+            var meetingId = 1L;
+
+            var existMeeting
+                = MeetingFixture.getCloseMeetingWithParticipantUserIds(List.of(userId, 2L, 3L));
+
+            given(meetingRepository.findById(anyLong()))
+                .willReturn(Optional.of(existMeeting));
+
+            // when
+            assertThatThrownBy(() -> meetingService.getParticipants(meetingId, notContainedUserId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("모임에 참여하지 않은 회원입니다.");
+        }
+    }
+}

--- a/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/net/teumteum/unit/user/controller/UserControllerTest.java
@@ -63,10 +63,11 @@ import org.springframework.test.web.servlet.MockMvc;
 public class UserControllerTest {
 
     @Autowired
-    ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
     @Autowired
     private MockMvc mockMvc;
+
     @MockBean
     private UserService userService;
 


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
- 모임 참여자 조회시, 로그인한 모임 참여자 응답 데이터는 제외하는 로직 및 포함 여부 확인 로직을 추가했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 로그인한 유저 포함 여부 확인 로직 추가
- [x] 응답 로그인한 유저 데이터 제외 로직 추가
- [x] 관련 단위 테스트 작성

## 🦀 이슈 넘버
- close #228 
<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
