### PR TITLE
fix: 모임 시작, 종료 알림이 모임 참여자가 3명 이상이 아니라면, 발행되지않도록 수정

### DIFF
--- a/src/main/java/net/teumteum/meeting/service/MeetingAlertPublisher.java
+++ b/src/main/java/net/teumteum/meeting/service/MeetingAlertPublisher.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MeetingAlertPublisher {
 
+    private static final String KR_TIME_ZONE = "Asia/Seoul";
     private static final String EVERY_ONE_MINUTES = "0 * * * * *";
     private static final String EVERY_12PM = "0 0 12 * * *";
 
@@ -24,18 +25,20 @@ public class MeetingAlertPublisher {
 
     @Scheduled(cron = EVERY_ONE_MINUTES)
     public void alertBeforeMeeting() {
-        var alertStart = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(5).withNano(0).withSecond(0);
+        var alertStart = LocalDateTime.now(ZoneId.of(KR_TIME_ZONE)).plusMinutes(5).withNano(0).withSecond(0);
         var alertEnd = alertStart.plusMinutes(1).withNano(0).withSecond(0);
         var alertTargets = meetingRepository.findAlertMeetings(alertStart, alertEnd);
-        alertTargets.forEach(meeting -> eventPublisher.publishEvent(
-                new BeforeMeetingAlerted(meeting.getParticipantUserIds())
-            )
-        );
+        alertTargets.stream()
+            .filter(alertTarget -> alertTarget.getParticipantUserIds().size() > 2)
+            .forEach(meeting -> eventPublisher.publishEvent(
+                    new BeforeMeetingAlerted(meeting.getParticipantUserIds())
+                )
+            );
     }
 
     @Scheduled(cron = EVERY_12PM)
     public void alertEndMeeting() {
-        var today = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+        var today = LocalDateTime.now(ZoneId.of(KR_TIME_ZONE))
             .withNano(0)
             .withSecond(0)
             .withMinute(0)
@@ -44,14 +47,16 @@ public class MeetingAlertPublisher {
         var yesterday = today.minusDays(1);
 
         var alertTargets = meetingRepository.findAlertMeetings(yesterday, today);
-        alertTargets.forEach(meeting -> eventPublisher.publishEvent(
-            new EndMeetingAlerted(meeting.getId(), meeting.getTitle(), meeting.getParticipantUserIds())
-        ));
+        alertTargets.stream()
+            .filter(alertTarget -> alertTarget.getParticipantUserIds().size() > 2)
+            .forEach(meeting -> eventPublisher.publishEvent(
+                new EndMeetingAlerted(meeting.getId(), meeting.getTitle(), meeting.getParticipantUserIds())
+            ));
     }
 
     @Scheduled(cron = EVERY_ONE_MINUTES)
     public void alertEndMeetingForQa() {
-        var today = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+        var today = LocalDateTime.now(ZoneId.of(KR_TIME_ZONE))
             .withNano(0)
             .withSecond(0)
             .withMinute(0)
@@ -61,8 +66,10 @@ public class MeetingAlertPublisher {
         var yesterday = today.minusDays(365);
 
         var alertTargets = meetingRepository.findAlertMeetings(yesterday, future);
-        alertTargets.forEach(meeting -> eventPublisher.publishEvent(
-            new EndMeetingAlerted(meeting.getId(), meeting.getTitle(), meeting.getParticipantUserIds())
-        ));
+        alertTargets.stream()
+            .filter(alertTarget -> alertTarget.getParticipantUserIds().size() > 2)
+            .forEach(meeting -> eventPublisher.publishEvent(
+                new EndMeetingAlerted(meeting.getId(), meeting.getTitle(), meeting.getParticipantUserIds())
+            ));
     }
 }


### PR DESCRIPTION
<!--
	PR 타이틀 = 행위: 도메인이 드러나는 설명 
-->

## 🚀 어떤 기능을 개발했나요?
모임 시작, 종료 알림을 모임 참여자가 3명 이상이 아니라면 발행되지 않도록 수정했습니다.

## 🕶️ 어떻게 해결했나요?
- [x] 모임 참가자 수 filter 추가

## 🦀 이슈 넘버
- close #230 

<!--
## (option) 어떤 부분에 집중하여 리뷰해야 할까요?
-->

<!--
## 참고자료
-->
